### PR TITLE
Fixed typo

### DIFF
--- a/docs/mixjs.md
+++ b/docs/mixjs.md
@@ -32,7 +32,7 @@ mix.js([
 
 
 // 3. For multiple entry/output points:
-mix.js('src/app.js', 'dist/'))
+mix.js('src/app.js', 'dist/')
    .js('src/forum.js', 'dist/');
 ```
 


### PR DESCRIPTION
Fixed code sample typo in `docs/mixjs.md`.