### PR TITLE
Fix package name

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -10,7 +10,7 @@ Begin by installing Laravel Mix through NPM or Yarn, and then copying the exampl
 mkdir my-app && cd my-app
 npm init -y
 npm install laravel-mix --save-dev
-cp -r node_modules/laravel-mixer/example/** ./
+cp -r node_modules/laravel-mix/example/** ./
 ```
 
 You should now have the following directory structure:


### PR DESCRIPTION
There is a wrong path in the installation guide: `laravel-mixer`. It should be `laravel-mix`. This PR fixes that.