### PR TITLE
Add multiple css preprocessor support

### DIFF
--- a/setup/webpack.config.js
+++ b/setup/webpack.config.js
@@ -86,7 +86,7 @@ module.exports.module = {
                 loaders: {
                     js: 'babel-loader' + Mix.babelConfig()
                 },
-                  
+
                 postcss: [
                     require('autoprefixer')
                 ]
@@ -124,7 +124,7 @@ if (Mix.sass) {
         loader: plugins.ExtractTextPlugin.extract({
             fallbackLoader: 'style-loader',
             loader: [
-                'css-loader', 'postcss-loader', 
+                'css-loader', 'postcss-loader',
                 'resolve-url-loader', 'sass-loader?sourceMap'
             ]
         })
@@ -170,7 +170,7 @@ module.exports.resolve = {
  | Stats
  |--------------------------------------------------------------------------
  |
- | By default, Webpack spits a lot of information out to the terminal, 
+ | By default, Webpack spits a lot of information out to the terminal,
  | each you time you compile. Let's keep things a bit more minimal
  | and hide a few of those bits and pieces. Adjust as you wish.
  |
@@ -224,7 +224,7 @@ module.exports.devServer = {
  | Plugins
  |--------------------------------------------------------------------------
  |
- | Lastly, we'll register a number of plugins to extend and configure 
+ | Lastly, we'll register a number of plugins to extend and configure
  | Webpack. To get you started, we've included a handful of useful
  | extensions, for versioning, OS notifications, and much more.
  |
@@ -255,7 +255,7 @@ module.exports.plugins.push(
     new webpack.LoaderOptionsPlugin({
         minimize: Mix.inProduction,
         options: {
-            postcss: [ 
+            postcss: [
                 require('autoprefixer')
             ],
             context: __dirname,
@@ -303,12 +303,14 @@ if (Mix.js.vendor) {
 }
 
 
-if (Mix.cssPreprocessor) {
-    module.exports.plugins.push(
-        new plugins.ExtractTextPlugin({
-            filename: Mix.cssOutput()
-        })
-    );
+if (Mix.cssPreprocessors) {
+    Mix.cssPreprocessors.forEach(function (preprocessor) {
+        module.exports.plugins.push(
+            new plugins.ExtractTextPlugin({
+                filename: Mix.cssOutput(preprocessor)
+            })
+        )
+    })
 }
 
 
@@ -322,8 +324,8 @@ if (Mix.inProduction) {
 
         new webpack.optimize.UglifyJsPlugin({
             sourceMap: true,
-            compress: { 
-                warnings: false 
+            compress: {
+                warnings: false
             }
         })
     ]);

--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,7 @@ module.exports.plugins = {
 
 /**
  * Register the Webpack entry/output paths.
- * 
+ *
  * @param {mixed}  entry
  * @param {string} output
  */
@@ -31,10 +31,10 @@ module.exports.js = (entry, output) => {
         ).parsePath();
     }
 
-    Mix.js = (Mix.js || []).concat({ 
-        entry, 
-        output, 
-        vendor: false 
+    Mix.js = (Mix.js || []).concat({
+        entry,
+        output,
+        vendor: false
     });
 
     return this;
@@ -44,8 +44,8 @@ module.exports.js = (entry, output) => {
 /**
  * Register vendor libs that should be extracted.
  * This helps drastically with long-term caching.
- * 
- * @param {array} libs 
+ *
+ * @param {array} libs
  */
 module.exports.extract = (libs) => {
     Mix.js.vendor = libs;
@@ -56,9 +56,9 @@ module.exports.extract = (libs) => {
 
 /**
  * Register Sass compilation.
- * 
+ *
  * @param {string} src
- * @param {string} output 
+ * @param {string} output
  */
 module.exports.sass = (src, output) => {
     return module.exports.preprocess('sass', src, output);
@@ -67,9 +67,9 @@ module.exports.sass = (src, output) => {
 
 /**
  * Register Less compilation.
- * 
- * @param {string} src  
- * @param {string} output 
+ *
+ * @param {string} src
+ * @param {string} output
  */
 module.exports.less = (src, output) => {
     return module.exports.preprocess('less', src, output);
@@ -78,10 +78,10 @@ module.exports.less = (src, output) => {
 
 /**
  * Register a generic CSS preprocessor.
- * 
- * @param  {string} type   
- * @param  {string} src    
- * @param  {string} output 
+ *
+ * @param  {string} type
+ * @param  {string} src
+ * @param  {string} output
  */
 module.exports.preprocess = (type, src, output) => {
     if (Mix[type]) {
@@ -101,7 +101,7 @@ module.exports.preprocess = (type, src, output) => {
 
     Mix[type] = { src, output };
 
-    Mix.cssPreprocessor = type;
+    Mix.cssPreprocessors = [].concat(Mix.cssPreprocessors || [], [type]);
 
     return this;
 };
@@ -109,9 +109,9 @@ module.exports.preprocess = (type, src, output) => {
 
 /**
  * Combine a collection of files.
- * 
- * @param {string|array} src  
- * @param {string}       output 
+ *
+ * @param {string|array} src
+ * @param {string}       output
  */
 module.exports.combine = (src, output) => {
     Mix.combine = (Mix.combine || []).concat({ src, output });
@@ -122,13 +122,13 @@ module.exports.combine = (src, output) => {
 
 /**
  * Copy one or more files to a new location.
- * 
+ *
  * @param {string} from
  * @param {string} to
  */
 module.exports.copy = (from, to) => {
-    Mix.copy = (Mix.copy || []).concat({ 
-        from, 
+    Mix.copy = (Mix.copy || []).concat({
+        from,
         to: path.resolve(__dirname, '../../', to)
     });
 
@@ -138,8 +138,8 @@ module.exports.copy = (from, to) => {
 
 /**
  * Minify the provided file.
- * 
- * @param {string|array} src  
+ *
+ * @param {string|array} src
  */
 module.exports.minify = (src) => {
     Mix.minify = (Mix.minify || []).concat(src);


### PR DESCRIPTION
Basically, I have vendor css framework, which is less, and my own styles, which is stylus. I needed a way to define both entries to have `vendor.css` and `app.css` separately. So I can now mix like this:
```js
mix
   .less(paths.assets + '/less/app.less', paths.public + '/css/vendor.css')
   // I have stylus declared in webpack.config.js like other preprocessors,
   // this PR doesn't include it
   .preprocess('stylus', paths.assets + '/stylus/app.styl', paths.public + '/css/app.css')
   // other stuff
```

PS. sorry for extra whitespace removal, editor did it automatically 😜