### PR TITLE
Fix default public and cache paths when not using Laravel

### DIFF
--- a/src/Mix.js
+++ b/src/Mix.js
@@ -19,8 +19,8 @@ class Mix {
         this.cssPreprocessor = false;
         this.inProduction = process.env.NODE_ENV === 'production';
 
-        this.publicPath = this.isUsingLaravel() ? 'public' : './';
-        this.cachePath = this.isUsingLaravel() ? 'storage/framework/cache' : './';
+        this.publicPath = this.isUsingLaravel() ? 'public' : '.';
+        this.cachePath = this.isUsingLaravel() ? 'storage/framework/cache' : '.';
 
         this.manifest = new Manifest(this.cachePath + '/Mix.json');
         this.versioning = new Versioning(this.manifest);


### PR DESCRIPTION
Fixes the default paths when not using Mix with a Laravel project.

Ran into this issue specifically with the `Mix.json` cache file using the path `.//Mix.json` by default.