### PR TITLE
Fix: TypeError: Mix.root is not a function

### DIFF
--- a/src/Mix.js
+++ b/src/Mix.js
@@ -185,6 +185,16 @@ class Mix {
 
 
     /**
+     * Path relative to root.
+     *
+     * @param {string|null} append
+     */
+    root(append = '') {
+        return this.paths.root(append);
+    }
+
+
+    /**
      * Determine if we are working with a Laravel project.
      */
     isUsingLaravel() {


### PR DESCRIPTION
`mix.copy` throws a **TypeError: Mix.root is not a function**

Fixed by adding a root method to *src/Mix.js*