### PR TITLE
Fix docs and paths issue

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -48,19 +48,24 @@ As a tip, consider adding the following NPM scripts to your `package.json` file,
 
 ```js
   "scripts": {
-    "webpack": "cross-env NODE_ENV=development webpack --progress --hide-modules",
-    "dev": "cross-env NODE_ENV=development webpack --watch --progress --hide-modules",
-    "hmr": "cross-env NODE_ENV=development webpack-dev-server --inline --hot",
-    "production": "cross-env NODE_ENV=production webpack --progress --hide-modules"
+    "webpack": "cross-env NODE_ENV=development webpack --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js",
+    "dev": "cross-env NODE_ENV=development webpack --watch --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js",
+    "hmr": "cross-env NODE_ENV=development webpack-dev-server --inline --hot --config=node_modules/laravel-mix/setup/webpack.config.js",
+    "production": "cross-env NODE_ENV=production webpack --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js"
   }
 ```
+
+If you would like to use your own `webpack.config.js` simply remove `--config=node_modules/laravel-mix/setup/webpack.config.js` from the scripts.
+
+Alternatively, if you would like to easily merge your own config with Laravel Mix's you can do so.
+[Quick Webpack Configuration](quick-webpack-configuration.md)
 
 ### Laravel Project
 
 Laravel 5.4 ships with everything you need to get started. Simply:
 
 * Install Laravel
-* Run `npm install` 
+* Run `npm install`
 * Visit your `webpack.mix.js file`, and get started!
 
 Now, from the command line, you may run `npm run dev` to watch your files for changes, and then recompile.

--- a/src/Mix.js
+++ b/src/Mix.js
@@ -68,7 +68,7 @@ class Mix {
         // We'll build up an entry object that the webpack.config.js
         // file will want to see. It'll include all mix.js() calls.
         let entry = this.js.reduce((result, paths) => {
-            result[paths.output.name] = paths.entry.map(src => src.path);
+            result[paths.output.base + '/' + paths.output.name] = paths.entry.map(src => src.path);
 
             return result;
         }, {});
@@ -93,7 +93,7 @@ class Mix {
 
         return {
             path: this.hmr ? '/' : this.publicPath,
-            filename: path.join(this.js[0].output.base, filename).replace(this.publicPath, ''),
+            filename: filename,
             publicPath: this.hmr ? 'http://localhost:8080/' : './'
         };
     }

--- a/test/mix.js
+++ b/test/mix.js
@@ -38,21 +38,20 @@ test('that it determines the CSS output path correctly.', t => {
 
 
 test('that it calculates the output correctly', t => {
-    mix.js('js/stub.js', 'dist').sass('sass/stub.scss', 'dist');
+    mix.js('js/stub.js', 'dist/test').sass('sass/stub.scss', 'dist');
 
     t.deepEqual({
         path: './public',
-        filename: 'dist/[name].js',
+        filename: '[name].js',
         publicPath: './'
     }, mix.config.output());
-
 
     // Enabling Hot Reloading should change this output.
     mix.config.hmr = true;
 
     t.deepEqual({
         path: '/',
-        filename: 'dist/[name].js',
+        filename: '[name].js',
         publicPath: 'http://localhost:8080/'
     }, mix.config.output());
 
@@ -63,17 +62,17 @@ test('that it calculates the output correctly', t => {
 
     t.deepEqual({
         path: './public',
-        filename: 'dist/[name].js',
+        filename: '[name].js',
         publicPath: './'
     }, mix.config.output());
 
 
-    // Enabling file versioning shoul dchange this output.
+    // Enabling file versioning should change this output.
     mix.version();
 
     t.deepEqual({
         path: './public',
-        filename: 'dist/[name].[hash].js',
+        filename: '[name].[hash].js',
         publicPath: './'
     }, mix.config.output());
 });


### PR DESCRIPTION
Paths Issue: Fix entry and output
Fixes the Mix.entry() and Mix.output() so that Javascript files can be put in separate folders.
Had to update a test to get it to pass but I have manually tested this with several configurations. As well as a small project I have been working on, on the side.

Closes #54

Docs Issue: fix package.json scripts
Fixes the config for scripts in package.json as well as adds a bit more information about using customised config and merging config.

Closes #55