### PR TITLE
Add default npm scripts

### DIFF
--- a/bin/laravel-mix.js
+++ b/bin/laravel-mix.js
@@ -1,0 +1,34 @@
+#!/usr/bin/env node
+
+const script = process.argv[2];
+const spawn = require('cross-spawn');
+
+let args = ''
+
+switch (script) {
+    case 'dev':
+        args = ['NODE_ENV=development', 'webpack', '--progress', '--hide-modules'];
+        break;
+
+    case 'watch':
+        args = ['NODE_ENV=development', 'webpack', '--watch', '--progress', '--hide-modules'];
+        break;
+
+    case 'hot':
+        args = ['NODE_ENV=development', 'webpack-dev-server', '--inline', '--hot'];
+    break;
+
+    case 'production':
+        args = ['NODE_ENV=production', 'webpack', '--progress', '--hide-modules'];
+        break;
+
+    default:
+        console.log(`Unknown script "${script}".`);
+        return;
+}
+
+args = args.concat(['--config=node_modules/laravel-mix/setup/webpack.config.js']);
+
+const result = spawn.sync('cross-env', args, { stdio: 'inherit' });
+
+process.exit(result.status);

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "clean-css": "^3.4.22",
     "concatenate": "0.0.1",
     "copy-webpack-plugin": "^4.0.1",
-    "cross-env": "^3.1.3",
+    "cross-env": "^3.1.4",
+    "cross-spawn": "^5.0.1",
     "css-loader": "^0.26.1",
     "extract-text-webpack-plugin": "^2.0.0-beta.4",
     "file-loader": "^0.9.0",
@@ -56,5 +57,8 @@
     "ava": "^0.17.0",
     "nyc": "^10.0.0",
     "sinon": "^1.17.7"
+  },
+  "bin": {
+    "laravel-mix": "./bin/laravel-mix.js"
   }
 }


### PR DESCRIPTION
This PR allows to just use :

```json
"scripts": {
  "dev": "laravel-mix dev",  
  "watch": "laravel-mix watch",
  "hot": "laravel-mix hot",
  "production": "laravel-mix production"
},
```

in your package.json instead of the long commands.