### PR TITLE
Deleted semicolon on line 15

### DIFF
--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -12,7 +12,7 @@ With versioning enabled, each time your code changes, a new hashed file will be 
 ```js
 let mix = require('laravel-mix').mix;
 
-mix.js('resources/assets/js/app.js', 'public/js');
+mix.js('resources/assets/js/app.js', 'public/js')
    .sass('resources/assets/sass/app.sass', 'public/css')
    .version();
 ```


### PR DESCRIPTION
the code block:

```js
let mix = require('laravel-mix').mix;

mix.js('resources/assets/js/app.js', 'public/js')
   .sass('resources/assets/sass/app.sass', 'public/css')
   .version();
```

had a semicolon after `mix.js('resources/assets/js/app.js', 'public/js')`