### PR TITLE
[Bugfix] Return the final webpack config in `finalize` method and export it.

### DIFF
--- a/setup/webpack.config.js
+++ b/setup/webpack.config.js
@@ -340,4 +340,4 @@ if (Mix.inProduction) {
  | If mix.webpackConfig() is called, we'll merge it in, and build!
  |
  */
-Mix.finalize(module.exports);
+module.exports = Mix.finalize(module.exports);

--- a/src/Mix.js
+++ b/src/Mix.js
@@ -49,7 +49,7 @@ class Mix {
      * @param {object} webpackConfig
      */
     finalize(webpackConfig) {
-        if (! this.webpackConfig) return;
+        if (! this.webpackConfig) return webpackConfig;
 
         mergeWith(this.webpackConfig, webpackConfig,
             (objValue, srcValue) => {
@@ -58,6 +58,8 @@ class Mix {
                 }
             }
         );
+
+        return this.webpackConfig;
     }
 
 


### PR DESCRIPTION
Previously, in the `Mix.finalize` method, the merged webpack config was stored in `this.webpackConfig` in case of we provide a custom config. 
But we don't do anything with that `this.webpackConfig`, so the final webpack config (**`module.exports`** in `webpack.config.js`) **was not updated**.

Now, we return in any case the final webpack config (merged, or not) and export it to webpack.

Without that, I didn't succeed to use the `mix.webpackConfig({})` helper :
https://github.com/JeffreyWay/laravel-mix/blob/master/docs/quick-webpack-configuration.md

I may miss something, let me know in case.

Thanks for your work, hope mine will be useful.