### PR TITLE
Determine the correct path to the notification icon

### DIFF
--- a/setup/webpack.config.js
+++ b/setup/webpack.config.js
@@ -268,7 +268,7 @@ if (Mix.notifications) {
         new plugins.WebpackNotifierPlugin({
             title: 'Laravel Mix',
             alwaysNotify: true,
-            contentImage: path.join(__dirname, 'node_modules/laravel-mix/icons/laravel.png')
+            contentImage: Mix.Paths.root('node_modules/laravel-mix/icons/laravel.png')
         })
     );
 }


### PR DESCRIPTION
Use `Mix.Paths.root` to determine the correct path to the notification icon.