### PR TITLE
Allow configuration of ProvidePlugin through “autoloading”

### DIFF
--- a/setup/webpack.config.js
+++ b/setup/webpack.config.js
@@ -234,11 +234,7 @@ module.exports.devServer = {
  */
 
 module.exports.plugins = (module.exports.plugins || []).concat([
-    new webpack.ProvidePlugin({
-        jQuery: 'jquery',
-        $: 'jquery',
-        jquery: 'jquery'
-    }),
+    new webpack.ProvidePlugin(Mix.js.autoload || {}),
 
     new plugins.FriendlyErrorsWebpackPlugin(),
 

--- a/setup/webpack.config.js
+++ b/setup/webpack.config.js
@@ -234,7 +234,11 @@ module.exports.devServer = {
  */
 
 module.exports.plugins = (module.exports.plugins || []).concat([
-    new webpack.ProvidePlugin(Mix.js.autoload || {}),
+    new webpack.ProvidePlugin(Mix.js.autoload || {
+        jQuery: 'jquery',
+        $: 'jquery',
+        jquery: 'jquery'
+    }),
 
     new plugins.FriendlyErrorsWebpackPlugin(),
 

--- a/src/index.js
+++ b/src/index.js
@@ -54,6 +54,27 @@ module.exports.extract = (libs) => {
 
 
 /**
+ * Register libraries to automatically "autoload" when
+ * the appropriate variable is references in js
+ *
+ * @param {object} libs
+ */
+module.exports.autoload = (libs) => {
+    let aliases = {};
+
+    Object.keys(libs).forEach(library => {
+        libs[library].forEach(alias => {
+            aliases[alias] = library;
+        });
+    });
+
+    Mix.js.autoload = aliases;
+
+    return this;
+};
+
+
+/**
  * Register Sass compilation.
  *
  * @param {string} src


### PR DESCRIPTION
I've added `mix.autoload()` to configure webpack's ProvidePlugin. This should solve the problem in issue https://github.com/JeffreyWay/laravel-mix/issues/96 with libraries that use jQuery. h/t to @QWp6t in that thread for the example API which I've implemented here.

Example usage:
```js
mix.autoload({
  'jquery': ['$', 'window.jQuery', 'jQuery'],
});
```

I've got it on my todo list to add tests to verify this works. Just wanted to get a PR out there to start a conversation on the suggested API.