### PR TITLE
copy command should have flatten paths. fix for issue #101

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -122,7 +122,8 @@ module.exports.combine = (src, output) => {
 module.exports.copy = (from, to) => {
     Mix.copy = (Mix.copy || []).concat({
         from,
-        to: Mix.Paths.root(to)
+        to: Mix.Paths.root(to),
+        flatten: true
     });
 
     return this;

--- a/test/mix.js
+++ b/test/mix.js
@@ -295,7 +295,7 @@ test('that the setter methods work properly', t => {
     mix.copy('fake/*.txt', path.resolve(__dirname, 'fixtures'));
     Mix.Paths.setRootPath(root);
     t.deepEqual(Mix.copy,
-        [{ from: 'fake/*.txt', to: Mix.Paths.root('fixtures') }]);
+        [{ from: 'fake/*.txt', to: Mix.Paths.root('fixtures'), flatten: true }]);
 
     Mix.minify = [];
     mix.minify('fake/test.txt');


### PR DESCRIPTION
As we read in documentation of [copy-webpack-plugin](https://github.com/kevlened/copy-webpack-plugin), property **flatten**:

> Removes all directory references and only copies file names
> If files have the same name, the result is non-deterministic