### PR TITLE
adding extra param to copy

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -139,12 +139,13 @@ module.exports.combine = (src, output) => {
  *
  * @param {string} from
  * @param {string} to
+ * @param {boolean} flatten
  */
-module.exports.copy = (from, to) => {
+module.exports.copy = (from, to, flatten = true) => {
     Mix.copy = (Mix.copy || []).concat({
         from,
         to: Mix.Paths.root(to),
-        flatten: true
+        flatten: flatten
     });
 
     return this;


### PR DESCRIPTION
when we copy directory by default all files in the old directory will be flatten and there is no option to control it since some time we need to copy directory with all subdirectory without flattening all files in the new destination 

issue report about it #152 