### PR TITLE
Add NamedModulesPlugin for HMR

### DIFF
--- a/setup/webpack.config.js
+++ b/setup/webpack.config.js
@@ -277,6 +277,13 @@ module.exports.plugins.push(
 );
 
 
+if (Mix.hmr) {
+    module.exports.plugins.push(
+        new webpack.NamedModulesPlugin()
+    );
+}
+
+
 if (Mix.versioning) {
     Mix.versioning.record();
 


### PR DESCRIPTION
Without `NamedModulesPlugin` you get the following messages in browser's developer console:
```
[WDS] App updated. Recompiling...
[WDS] App hot update...
[HMR] Checking for updates on the server...
[HMR] Updated modules:
[HMR]  - 312
[HMR] Consider using the NamedModulesPlugin for module names.
[HMR] App is up to date.
```

With `NamedModulesPlugin`
```
[WDS] App updated. Recompiling...
[WDS] App hot update...
[HMR] Checking for updates on the server...
[HMR] Updated modules:
[HMR]  - ./node_modules/vue-loader/lib/template-compiler.js?id=data-v-249d8d81!./node_modules/vue-loader/lib/selector.js?type=template&index=0!./resources/assets/js/components/Example.vue
[HMR] App is up to date.
```