### PR TITLE
source maps for less

### DIFF
--- a/setup/webpack.config.js
+++ b/setup/webpack.config.js
@@ -127,16 +127,20 @@ if (Mix.cssPreprocessor) {
             Mix.cssOutput(toCompile)
         );
 
+        let sourceMap = Mix.sourcemaps ? '?sourceMap' : '';
         module.exports.module.rules.push({
             test: new RegExp(toCompile.src.file),
             loader: extractPlugin.extract({
                 fallbackLoader: 'style-loader',
                 loader: [
-                    'css-loader',
-                    'postcss-loader',
-                    'resolve-url-loader',
-                    (Mix.cssPreprocessor == 'sass') ? 'sass-loader?sourceMap&precision=8' : 'less-loader'
-                ]
+                    'css-loader' + sourceMap,
+                    'postcss-loader' + sourceMap
+                ].concat(Mix.cssPreprocessor == 'sass' ? [
+                    'resolve-url-loader' + sourceMap,
+                    'sass-loader?sourceMap&precision=8'
+                ] : [
+                    'less-loader' + sourceMap
+                ])
             })
         });
 


### PR DESCRIPTION
`resolve-url-loader` is only for sass. It fails when using less-loader with source map, so I had to split that.