### PR TITLE
Add ability to compile less and sass files

### DIFF
--- a/setup/webpack.config.js
+++ b/setup/webpack.config.js
@@ -132,7 +132,7 @@ if (Mix.stylePreprocessors) {
                         'css-loader',
                         'postcss-loader',
                         'resolve-url-loader',
-                        (type == 'sass') ? 'sass-loader?sourceMap' : 'less-loader'
+                        (type == 'sass') ? 'sass-loader?sourceMap&precision=8' : 'less-loader'
                     ]
                 })
             });

--- a/setup/webpack.config.js
+++ b/setup/webpack.config.js
@@ -115,29 +115,32 @@ module.exports.module = {
 };
 
 
-if (Mix.cssPreprocessor) {
-    Mix[Mix.cssPreprocessor].forEach(toCompile => {
-        let extractPlugin = new plugins.ExtractTextPlugin(
-            Mix.cssOutput(toCompile)
-        );
+if (Mix.stylePreprocessors) {
+    Mix.stylePreprocessors.forEach(type => {
+        if (!Mix[type]) return;
 
-        module.exports.module.rules.push({
-            test: new RegExp(toCompile.src.file),
-            loader: extractPlugin.extract({
-                fallbackLoader: 'style-loader',
-                loader: [
-                    'css-loader',
-                    'postcss-loader',
-                    'resolve-url-loader',
-                    (Mix.cssPreprocessor == 'sass') ? 'sass-loader?sourceMap&precision=8' : 'less-loader'
-                ]
-            })
+        Mix[type].forEach(toCompile => {
+            let extractPlugin = new plugins.ExtractTextPlugin(
+                Mix.cssOutput(toCompile)
+            );
+
+            module.exports.module.rules.push({
+                test: new RegExp(toCompile.src.file),
+                loader: extractPlugin.extract({
+                    fallbackLoader: 'style-loader',
+                    loader: [
+                        'css-loader',
+                        'postcss-loader',
+                        'resolve-url-loader',
+                        (type == 'sass') ? 'sass-loader?sourceMap' : 'less-loader'
+                    ]
+                })
+            });
+
+            module.exports.plugins = (module.exports.plugins || []).concat(extractPlugin);
         });
-
-        module.exports.plugins = (module.exports.plugins || []).concat(extractPlugin);
     });
 }
-
 
 
 /*

--- a/src/Mix.js
+++ b/src/Mix.js
@@ -88,11 +88,15 @@ class Mix {
             }, {});
         }
 
-        if (this.cssPreprocessor) {
-            let stylesheets = this[this.cssPreprocessor].map(entry => entry.src.path);
-            let name = Object.keys(entry)[0];
+        if (this.stylePreprocessors) {
+            this.stylePreprocessors.forEach(type => {
+                if (!this[type]) return;
 
-            entry[name] = entry[name].concat(stylesheets);
+                let stylesheets = this[type].map(entry => entry.src.path);
+                let name = Object.keys(entry)[0];
+
+                entry[name] = entry[name].concat(stylesheets);
+            });
         }
 
         if (this.js.length && this.js.vendor) {

--- a/src/index.js
+++ b/src/index.js
@@ -117,7 +117,7 @@ module.exports.preprocess = (type, src, output) => {
 
     Mix[type] = (Mix[type] || []).concat({ src, output });
 
-    Mix.cssPreprocessor = type;
+    Mix.stylePreprocessors = (Mix.stylePreprocessors || []).concat(type).filter((v, i, a) => a.indexOf(v) === i);
 
     return this;
 };

--- a/test/mix.js
+++ b/test/mix.js
@@ -109,7 +109,7 @@ test('that it determines the CSS output path correctly.', t => {
     Mix.versioning = false;
     Mix.inProduction = false;
 
-    // Test else path for this.cssPreprocessor being empty
+    // Test else path for this.stylePreprocessors being empty
     Mix.stylePreprocessors = false;
     t.deepEqual(Mix.entry(), {
         'dist/stub': [path.resolve(__dirname, '../js/stub.js')]

--- a/test/mix.js
+++ b/test/mix.js
@@ -110,7 +110,7 @@ test('that it determines the CSS output path correctly.', t => {
     Mix.inProduction = false;
 
     // Test else path for this.cssPreprocessor being empty
-    Mix.cssPreprocessor = false;
+    Mix.stylePreprocessors = false;
     t.deepEqual(Mix.entry(), {
         'dist/stub': [path.resolve(__dirname, '../js/stub.js')]
     });


### PR DESCRIPTION
Adds ability to compile less and sass files in one go,

```
mix.less('resources/assets/less/style.less', 'public/assets/css/less.css')
   .less('resources/assets/less/style2.less', 'public/assets/css/less2.css')
   .sass('resources/assets/sass/style2.scss', 'public/assets/css')
   .sass('resources/assets/sass/style.scss', 'public/assets/css');
```