### PR TITLE
Docs: Update script names to match with Laravel's package.json

### DIFF
--- a/docs/hot-module-replacement.md
+++ b/docs/hot-module-replacement.md
@@ -10,9 +10,9 @@ Both Laravel and Laravel Mix work together to abstract away the complexities in 
 
 ```js
   "scripts": {
-    "webpack": "cross-env NODE_ENV=development webpack --progress --hide-modules",
-    "dev": "cross-env NODE_ENV=development webpack --watch --progress --hide-modules",
-    "hmr": "cross-env NODE_ENV=development webpack-dev-server --inline --hot",
+    "dev": "cross-env NODE_ENV=development webpack --progress --hide-modules",
+    "watch": "cross-env NODE_ENV=development webpack --watch --progress --hide-modules",
+    "hot": "cross-env NODE_ENV=development webpack-dev-server --inline --hot",
     "production": "cross-env NODE_ENV=production webpack --progress --hide-modules"
   }
 ```


### PR DESCRIPTION
I updated only this section because this one is specifically about Laravel.

However there are a few other sections with different script names, but they aren't specifically about Laravel ([installation](https://github.com/JeffreyWay/laravel-mix/blob/master/docs/installation.md#npm-scripts) and [faq](https://github.com/JeffreyWay/laravel-mix/blob/master/docs/faq.md#my-code-isnt-being-minified)). Shall I update those as well?