### PR TITLE
Fix dev-server error when using copy. fix for issue #63

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -148,7 +148,8 @@ module.exports.combine = (src, output) => {
 module.exports.copy = (from, to, flatten = true) => {
     Mix.copy = (Mix.copy || []).concat({
         from,
-        to: Mix.Paths.root(to),
+        to,
+        context: Mix.Paths.root(),
         flatten: flatten
     });
 


### PR DESCRIPTION
When I used the copy function and run npm run dev I get the following error:

ERROR in [copy-webpack-plugin] Using older versions of webpack-dev-server, devServer.outputPath must be defined to write to absolute paths

*On Windows
**Not in leravel project

#63 