### PR TITLE
Replaced references to 'hmr' with 'hot'

### DIFF
--- a/docs/hot-module-replacement.md
+++ b/docs/hot-module-replacement.md
@@ -17,7 +17,7 @@ Both Laravel and Laravel Mix work together to abstract away the complexities in 
   }
 ```
 
-Take note of the `hmr` option; this is the one you want. From the command line, run `npm run hmr` to boot up a Node server and monitor your bundle for changes. Next, load your Laravel app in the browser, as you normally would. Perhaps, `http://my-app.dev`.
+Take note of the `hot` option; this is the one you want. From the command line, run `npm run hot` to boot up a Node server and monitor your bundle for changes. Next, load your Laravel app in the browser, as you normally would. Perhaps, `http://my-app.dev`.
 
 The key to making hot reloading work within a Laravel application is ensuring that all script sources reference the Node server URL that we just booted up. This will be [http://localhost:8080](http://localhost:8080). Now you could of course manually update your HTML/Blade files, like so:
 
@@ -40,7 +40,7 @@ However, it can be a burden to manually change this URL for production deploys. 
 </body>
 ```
 
-With this adjustment, Laravel will do the work for you. If you run 'npm run hmr' to enable hot reloading, the function will set the necessary `http://localhost:8080` base url. If, instead, you use `npm run dev` or `npm run production`, it'll use your domain as the base.
+With this adjustment, Laravel will do the work for you. If you run 'npm run hot' to enable hot reloading, the function will set the necessary `http://localhost:8080` base url. If, instead, you use `npm run dev` or `npm run production`, it'll use your domain as the base.
 
 
 


### PR DESCRIPTION
In the documentation there is a mention to run `npm run hmr` but these don't exists anymore when we create a new Laravel project, it has been replaced by hot. Changed the documentation accordingly.