### PR TITLE
Allow jsx

### DIFF
--- a/setup/webpack.config.js
+++ b/setup/webpack.config.js
@@ -90,7 +90,7 @@ module.exports.module = {
         },
 
         {
-            test: /\.js$/,
+            test: /\.jsx?$/,
             exclude: /(node_modules|bower_components)/,
             loader: 'babel-loader' + Mix.babelConfig()
         },


### PR DESCRIPTION
Since `jsx` is listed in `resolve.extensions`, I think it makes sense to apply babel on jsx files. No other changes necessary since transformation happens through babel, which would be set up in the user's `.babelrc`.