### PR TITLE
Fixing the JSDoc of mix.js

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,7 @@ let Verify = require('./Verify');
 /**
  * Register the Webpack entry/output paths.
  *
- * @param {mixed}  entry
+ * @param {string|array}  entry
  * @param {string} output
  */
 module.exports.js = (entry, output) => {


### PR DESCRIPTION
`mixed` is not a valid JSDoc parameter, also using it instead of `string|array` is not consistent with other functions in the same file.