### PR TITLE
Fix record function in Version class returning this

### DIFF
--- a/src/Versioning.js
+++ b/src/Versioning.js
@@ -19,7 +19,7 @@ class Versioning {
      * Record versioned files.
      */
     record() {
-        if (! this.manifest.exists()) return;
+        if (! this.manifest.exists()) return this;
 
         this.reset();
 


### PR DESCRIPTION
This simple "return this" makes the following code works when the manifest does not exist.

```
            this.versioning = new Versioning(this.manifest).record();

            this.events.listen('build', () => {
                this.versioning.prune(this.publicPath);
            });
```

```
this.versioning.prune(this.publicPath);
                               ^
TypeError: Cannot read property 'prune' of undefined

```