### PR TITLE
Fix for deprecation warning

### DIFF
--- a/setup/webpack.config.js
+++ b/setup/webpack.config.js
@@ -131,9 +131,9 @@ if (Mix.preprocessors) {
 
         module.exports.module.rules.push({
             test: new RegExp(toCompile.src.path.replace(/\\/g, '\\\\') + '$'),
-            loader: extractPlugin.extract({
-                fallbackLoader: 'style-loader',
-                loader: [
+            use: extractPlugin.extract({
+                fallback: 'style-loader',
+                use: [
                     { loader: 'css-loader' + sourceMap },
                     { loader: 'postcss-loader' + sourceMap }
                 ].concat(


### PR DESCRIPTION
I know very little of Webpack so i have no idea what the consequences are of changing this but it seems to get rid of the following warning:
```
fallbackLoader option has been deprecated - replace with "fallback"
loader option has been deprecated - replace with "use"
```