### PR TITLE
fix sass-loader issue

### DIFF
--- a/setup/webpack.config.js
+++ b/setup/webpack.config.js
@@ -140,11 +140,11 @@ if (Mix.preprocessors) {
                     toCompile.type == 'sass' ? [
                         { loader: 'resolve-url-loader' + sourceMap },
                         {
-                            loader: 'sass-loader?sourceMap',
+                            loader: 'sass-loader',
                             options: Object.assign({
                                 precision: 8,
                                 outputStyle: 'expanded'
-                            }, toCompile.pluginOptions)
+                            }, toCompile.pluginOptions, { sourceMap: true })
                         }
                     ] : [
                         {


### PR DESCRIPTION
#305 

I've create a PR #279 before, but rejected because the `sourceMap` of sass-loader is required and should not be override by user setting.

Seems that use both `query parameters` and `loader options` still get conflict and error.

So, pass `sourceMap` setting in the last option to override all set before.