### PR TITLE
fix hmr issue

### DIFF
--- a/setup/webpack.config.js
+++ b/setup/webpack.config.js
@@ -312,7 +312,7 @@ if (Mix.extract) {
     module.exports.plugins.push(
         new webpack.optimize.CommonsChunkPlugin({
             names: Mix.entryBuilder.extractions.concat([
-                path.join(Mix.js.base, 'manifest')
+                path.join(Mix.js.base, 'manifest').replace(/\\/g, '/')
             ]),
             minChunks: Infinity
         })

--- a/src/index.js
+++ b/src/index.js
@@ -47,7 +47,7 @@ module.exports.extract = (libs, output) => {
                              .replace(Mix.publicPath, '');
             }
 
-            return path.join(Mix.js.base, 'vendor');
+            return path.join(Mix.js.base, 'vendor').replace(/\\/g, '/');
         }
     });
 


### PR DESCRIPTION
replace backslash with slash in vendor extraction path.

![image](https://cloud.githubusercontent.com/assets/8281226/22681025/23271598-ed46-11e6-8294-bbcd74efabba.png)

Mix helper can return `/js/vendor.js` for your request, the right thing.
but hmr wants quite the same url, won't treat backslash as windows directory delimiter.

![image](https://cloud.githubusercontent.com/assets/8281226/22681318/8236ccf8-ed47-11e6-8725-e6a0fddb6999.png)
