### PR TITLE
Ability to set prefix for generated asset paths, fixes #339

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,22 @@
+<!-- *Before creating an issue please make sure you are using the latest version of laravel-mix.* -->
+
+### What is the current behavior?
+
+
+
+### What is the expected or desired behavior?
+
+
+
+---
+
+**Steps to reproduce, including full log output:**
+<!-- If you can, provide a link to a public repository which contains the files necessary to reproduce this. -->
+
+
+
+**Local environment:**
+
+Operating System: X
+
+NPM/Node version: X

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,22 +1,24 @@
-<!-- *Before creating an issue please make sure you are using the latest version of laravel-mix.* -->
+<!-- 
+    Before posting this issue, please perform the following steps, and confirm that the issue is still present.
 
-### What is the current behavior?
+1. Update Laravel Mix to the latest version.
+2. Nuke your dependencies, and reinstall from scratch: `rm -rf node_modules && npm install`.
+3. Check your `package.json` file, and ensure that there are no old Laravel Elixir dependencies that might be interfering with Mix.
+
+-->
+
+- Laravel Mix Version: #.#.#
+- Node Version (`node -v`): 
+- NPM Version (`npm -v`): 
+- OS: 
+
+### Description:
 
 
+### Steps To Reproduce:
 
-### What is the expected or desired behavior?
+<!-- 
 
+Your issue will be addressed much more quickly if you can provide us exact steps to reproduce the problem.  Bonus points, if you link us to an installable GitHub repository that illustrates the problem.
 
-
----
-
-**Steps to reproduce, including full log output:**
-<!-- If you can, provide a link to a public repository which contains the files necessary to reproduce this. -->
-
-
-
-**Local environment:**
-
-Operating System: X
-
-NPM/Node version: X
+-->

--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,6 @@
 docs/
 test/
+.github/
 .nyc_output
 .idea
 coverage

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -2,7 +2,7 @@
 
 ```js
 mix.js('src', 'output')
-   .version();
+   .version([]);
 ```
 
 To assist with long-term caching, Laravel Mix provides the `mix.version()` method, which enables file name hashing. such as `app.8e5c48eadbfdd5458ec6.js`. This is useful for cache-busting. Imagine that your server automatically caches scripts for a year, to improve performance. That's great, but, each time you make a change to your application code, you need some way to instruct the server to bust the cache. This is typically done through the use of query strings, or file hashing.
@@ -24,10 +24,6 @@ As an example, try running`webpack --watch`, and then change a bit of your JavaS
 ### Importing Versioned Files
 
 This all begs the question: how exactly do we include these versioned scripts and stylesheets into your HTML, if the names keep changing? Yes, that can be tricky. The answer will be dependent upon the type of application you're building. For SPAs, you may dynamically read Laravel Mix's generated `manifest.json` file, extract the asset file names \(these will be updated for each compile to reflect the new versioned file\), and then generate your HTML.
-
-#### Note
-
-Versioning is only performed when running in `production` mode.  (ie with `NODE_ENV=production`)
 
 #### Laravel Users
 
@@ -52,3 +48,14 @@ For Laravel projects, a solution is provided out of the box. Simply call the glo
 ```
 
 Pass the unhashed file path to the `mix()` function, and, behind the scenes, we'll figure out which script or stylesheet should be imported. Please note that you may/should use this function, even if you're not versioning your files.
+
+
+### Versioning Extra Files
+
+The `mix.version()` will automatically version any compiled JavaScript, Sass/Less, or combined files. However, if you'd also like to version extra files as part of your build, simply pass a path, or array of paths, to the method, like so:
+
+```js
+mix.version(['public/js/random.js']);
+```
+
+Now, we'll still version any relevant compiled files, but we'll also create a `public/js/random.{hash}.js` file, and update your `mix-manifest.json` file.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "laravel-mix",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Laravel Mix is an elegant wrapper around Webpack for the 80% use case.",
   "main": "src/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "laravel-mix",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Laravel Mix is an elegant wrapper around Webpack for the 80% use case.",
   "main": "src/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "laravel-mix",
-  "version": "0.6.3",
+  "version": "0.7.0",
   "description": "Laravel Mix is an elegant wrapper around Webpack for the 80% use case.",
   "main": "src/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "copy-webpack-plugin": "^4.0.1",
     "cross-env": "^3.1.3",
     "css-loader": "^0.26.1",
-    "extract-text-webpack-plugin": "^2.0.0-beta.4",
+    "extract-text-webpack-plugin": "^2.0.0-rc.3",
     "file-loader": "^0.9.0",
     "friendly-errors-webpack-plugin": "^1.1.3",
     "fs": "0.0.1-security",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "file-loader": "^0.9.0",
     "friendly-errors-webpack-plugin": "^1.1.3",
     "fs": "0.0.1-security",
+    "html-loader": "^0.4.4",
     "less": "^2.7.1",
     "less-loader": "^2.2.3",
     "lodash": "^4.17.4",

--- a/setup/webpack.config.js
+++ b/setup/webpack.config.js
@@ -101,6 +101,11 @@ module.exports.module = {
         },
 
         {
+            test: /\.html$/,
+            loaders: ['html-loader']
+        },
+
+        {
             test: /\.(png|jpg|gif)$/,
             loader: 'file-loader',
             options: {

--- a/setup/webpack.config.js
+++ b/setup/webpack.config.js
@@ -77,7 +77,21 @@ module.exports.module = {
             test: /\.vue$/,
             loader: 'vue-loader',
             options: {
-                loaders: {
+                loaders: Mix.options.extractVueStyles ? {
+                    js: 'babel-loader' + Mix.babelConfig(),
+                    scss: plugins.ExtractTextPlugin.extract({
+                        use: 'css-loader!sass-loader',
+                        fallback: 'vue-style-loader'
+                    }),
+                    sass: plugins.ExtractTextPlugin.extract({
+                        use: 'css-loader!sass-loader?indentedSyntax',
+                        fallback: 'vue-style-loader'
+                    }),
+                    css: plugins.ExtractTextPlugin.extract({
+                        use: 'css-loader',
+                        fallback: 'vue-style-loader'
+                    })
+                }: {
                     js: 'babel-loader' + Mix.babelConfig(),
                     scss: 'vue-style-loader!css-loader!sass-loader',
                     sass: 'vue-style-loader!css-loader!sass-loader?indentedSyntax'
@@ -163,6 +177,10 @@ if (Mix.preprocessors) {
 
         module.exports.plugins = (module.exports.plugins || []).concat(extractPlugin);
     });
+} else if (Mix.options.extractVueStyles) {
+    module.exports.plugins = (module.exports.plugins || []).concat(
+        new plugins.ExtractTextPlugin(path.join(Mix.js.base, 'vue-styles.css'))
+    );
 }
 
 

--- a/setup/webpack.config.js
+++ b/setup/webpack.config.js
@@ -124,7 +124,7 @@ module.exports.module = {
             loader: 'file-loader',
             options: {
                 name: 'images/[name].[ext]?[hash]',
-                publicPath: '/'
+                publicPath: Mix.resourceRoot
             }
         },
 
@@ -133,7 +133,7 @@ module.exports.module = {
             loader: 'file-loader',
             options: {
                 name: 'fonts/[name].[ext]?[hash]',
-                publicPath: '/'
+                publicPath: Mix.resourceRoot
             }
         }
     ]

--- a/setup/webpack.mix.js
+++ b/setup/webpack.mix.js
@@ -29,3 +29,6 @@ mix.js('src/app.js', 'dist/')
 // mix.autoload({}); <-- Will be passed to Webpack's ProvidePlugin.
 // mix.webpackConfig({}); <-- Override webpack.config.js, without editing the file directly.
 // mix.then(function () {}) <-- Will be triggered each time Webpack finishes building.
+// mix.options({
+//   extractVueStyles: false // default
+// });

--- a/setup/webpack.mix.js
+++ b/setup/webpack.mix.js
@@ -26,6 +26,7 @@ mix.js('src/app.js', 'dist/')
 // mix.version(); // Enable versioning.
 // mix.disableNotifications();
 // mix.setPublicPath('path/to/public');
+// mix.setResourceRoot('prefix/for/resource/locators');
 // mix.autoload({}); <-- Will be passed to Webpack's ProvidePlugin.
 // mix.webpackConfig({}); <-- Override webpack.config.js, without editing the file directly.
 // mix.then(function () {}) <-- Will be triggered each time Webpack finishes building.

--- a/src/Collection.js
+++ b/src/Collection.js
@@ -13,7 +13,7 @@ class Collection {
      * Add a new key-value pair to the collection.
      *
      * @param {string}       name
-     * @param {string|array} files
+     * @param {string|Array} files
      */
     add(name, files) {
         if (! this.items[name]) {
@@ -27,7 +27,7 @@ class Collection {
     /**
      * Get the underlying items for the collection.
      *
-     * @return {array}
+     * @return {Array}
      */
     get() {
         return this.items;

--- a/src/Concat.js
+++ b/src/Concat.js
@@ -87,7 +87,7 @@ class Concat {
             let versionedPath = File.find(files.outputOriginal)
                 .versionedPath(md5(mergedFileContents));
 
-            files.output = output.rename(versionedPath).path();
+            files.output = output.rename(versionedPath).file;
         }
 
         if (process.env.NODE_ENV === 'production') {

--- a/src/Dispatcher.js
+++ b/src/Dispatcher.js
@@ -10,7 +10,7 @@ class Dispatcher {
     /**
      * Listen for the given event.
      *
-     * @param {string|array}   events
+     * @param {string|Array}   events
      * @param {Function}       handler
      */
     listen(events, handler) {
@@ -26,7 +26,7 @@ class Dispatcher {
      * Trigger all handlers for the given event.
      *
      * @param {string} event
-     * @param {mixed} data
+     * @param {*} data
      */
     fire(event, data) {
         if (! this.events[event]) return false;

--- a/src/File.js
+++ b/src/File.js
@@ -126,11 +126,11 @@ class File {
      * Version the current file.
      */
     version() {
-        let hash = md5(this.read());
+        let contents = this.read();
 
-        let versionedPath = this.versionedPath(hash);
+        let versionedPath = this.versionedPath(md5(contents));
 
-        return new File(versionedPath).write(this.read());
+        return new File(versionedPath).write(contents);
     }
 
 

--- a/src/File.js
+++ b/src/File.js
@@ -1,5 +1,6 @@
 let fs = require('fs');
 let path = require('path');
+let md5 = require('md5');
 let chokidar = require('chokidar');
 let mkdirp = require('mkdirp');
 let uglify = require('uglify-js');
@@ -107,7 +108,7 @@ class File {
     watch(callback) {
         return chokidar.watch(
             this.path(), { persistent: true }
-        ).on('change', callback);
+        ).on('change', () => callback(this));
     }
 
 
@@ -122,11 +123,25 @@ class File {
 
 
     /**
+     * Version the current file.
+     */
+    version() {
+        let hash = md5(this.read());
+
+        let versionedPath = this.versionedPath(hash);
+
+        return new File(versionedPath).write(this.read());
+    }
+
+
+    /**
      * Fetch a full, versioned path to the file.
      *
      * @param {string} hash
      */
     versionedPath(hash) {
+        if (! hash) hash = md5(this.read());
+
         return this.parsePath().hashedPath.replace('[hash]', hash);
     }
 

--- a/src/File.js
+++ b/src/File.js
@@ -178,16 +178,6 @@ class File {
 
         return this;
     }
-
-
-    /**
-     * Copy the current file to a new location.
-     *
-     * @param {string} to
-     */
-    copy(to) {
-        new File(to).write(this.read());
-    }
 }
 
 module.exports = File;

--- a/src/Manifest.js
+++ b/src/Manifest.js
@@ -11,7 +11,7 @@ class Manifest {
     constructor(path) {
         this.path = path;
         this.manifest = {};
-        this.loaded = false;
+        this.cache = this.exists() ? this.read() : {};
     }
 
 
@@ -21,8 +21,11 @@ class Manifest {
      * @param {string} original
      * @param {string} modified
      */
-    add(original, modified) {
-        this.manifest[this.preparePath(original)] = this.preparePath(modified);
+    add(file) {
+        let original = this.preparePath(file.file);
+        let modified = this.preparePath(file.versionedPath());
+
+        this.manifest[original] = modified;
 
         return this;
     }
@@ -35,12 +38,12 @@ class Manifest {
      */
     get(original) {
         if (original) {
-            original = this.preparePath(original);
+            if (original instanceof File) original = original.file;
 
-            return this.manifest[original];
+            return this.manifest[this.preparePath(original)];
         }
 
-        return this.loaded ? this.manifest : this.read();
+        return this.manifest;
     }
 
 
@@ -127,15 +130,7 @@ class Manifest {
      * Retrieve the JSON output from the manifest file.
      */
     read() {
-        if (! this.loaded) {
-            this.manifest = JSON.parse(File.find(this.path).read());
-
-            this.loaded = true;
-
-            return this.manifest;
-        }
-
-        return this.manifest;
+        return JSON.parse(File.find(this.path).read());
     }
 
 

--- a/src/Manifest.js
+++ b/src/Manifest.js
@@ -86,7 +86,7 @@ class Manifest {
     /**
      * Append any mix.combine()'d output paths to the manifest.
      *
-     * @param {array} combine
+     * @param {Array} toCombine
      */
     appendCombinedFiles(toCombine) {
         let output = this.preparePath(toCombine.output);

--- a/src/Manifest.js
+++ b/src/Manifest.js
@@ -18,8 +18,7 @@ class Manifest {
     /**
      * Add a key-value pair to the manifest file.
      *
-     * @param {string} original
-     * @param {string} modified
+     * @param {File} file
      */
     add(file) {
         let original = this.preparePath(file.file);

--- a/src/Mix.js
+++ b/src/Mix.js
@@ -129,7 +129,7 @@ class Mix {
     /**
      * Detect if the user desires hot reloading.
      *
-     * @param {bool} force
+     * @param {boolean} force
      */
     detectHotReloading(force = false) {
         let file = new this.File(this.publicPath + '/hot');

--- a/src/Mix.js
+++ b/src/Mix.js
@@ -59,12 +59,9 @@ class Mix {
      * Enable file versioning for the build.
      */
     enableVersioning() {
-        this.versioning = new Versioning(this.version, this.manifest, this.publicPath);
-
-        this.versioning
-            .writeHashedFiles()
-            .record()
-            .watch();
+        this.versioning = new Versioning(
+            this.version, this.manifest, this.publicPath
+        ).watch();
 
         this.events.listen(
             ['build', 'combined'], () => this.versioning.prune()

--- a/src/Mix.js
+++ b/src/Mix.js
@@ -59,7 +59,7 @@ class Mix {
      * Enable file versioning for the build.
      */
     enableVersioning() {
-        this.versioning = new Versioning(this.version, this.manifest);
+        this.versioning = new Versioning(this.version, this.manifest, this.publicPath);
 
         this.versioning
             .writeHashedFiles()
@@ -67,7 +67,7 @@ class Mix {
             .watch();
 
         this.events.listen(
-            ['build', 'combined'], () => this.versioning.prune(this.publicPath)
+            ['build', 'combined'], () => this.versioning.prune()
         );
 
         this.concat.enableVersioning();

--- a/src/Mix.js
+++ b/src/Mix.js
@@ -192,6 +192,7 @@ class Mix {
         this.entryBuilder.reset();
         this.events = new Dispatcher;
         this.concat = new Concat(this.events);
+        this.copy = [];
 
         return this;
     }

--- a/src/Mix.js
+++ b/src/Mix.js
@@ -25,6 +25,7 @@ class Mix {
         this.concat = new Concat(this.events);
         this.inProduction = process.env.NODE_ENV === 'production';
         this.publicPath = './';
+        this.resourceRoot = '/';
     }
 
 
@@ -185,6 +186,7 @@ class Mix {
         ].forEach(prop => this[prop] = null);
 
         this.publicPath = './';
+        this.resourceRoot = '/';
         this.js = [];
         this.entryBuilder.reset();
         this.events = new Dispatcher;

--- a/src/Verify.js
+++ b/src/Verify.js
@@ -5,8 +5,8 @@ class Verify {
     /**
      * Verify that the call the mix.js() is valid.
      *
-     * @param {mixed} entry
-     * @param {mixed} output
+     * @param {*} entry
+     * @param {*} output
      */
     static js(entry, output) {
         assert(
@@ -25,7 +25,7 @@ class Verify {
      * Verify that the calls the mix.sass() and mix.less() are valid.
      *
      * @param {string} type
-     * @param {string} entry
+     * @param {string} src
      * @param {string} output
      */
     static preprocessor(type, src, output) {
@@ -44,7 +44,7 @@ class Verify {
     /**
      * Verify that the call the mix.extract() is valid.
      *
-     * @param {array} entry
+     * @param {Array} libs
      */
     static extract(libs) {
         assert(
@@ -57,7 +57,7 @@ class Verify {
     /**
      * Verify that the call the mix.combine() is valid.
      *
-     * @param {array} src
+     * @param {Array} src
      */
     static combine(src) {
         assert(

--- a/src/Verify.js
+++ b/src/Verify.js
@@ -64,13 +64,6 @@ class Verify {
             Array.isArray(src),
             'mix.combine() requires an array as its first parameter.'
         );
-
-        src.forEach(file => {
-            assert(
-                File.exists(file),
-                `Mix.combine() error: "${file} does not exist.`
-            );
-        });
     }
 }
 

--- a/src/Versioning.js
+++ b/src/Versioning.js
@@ -6,7 +6,7 @@ class Versioning {
     /**
      * Create a new Versioning instance.
      *
-     * @param {array}  manualFiles
+     * @param {Array}  manualFiles
      * @param {object} manifest
      * @param {string} publicPath
      */

--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,7 @@ let Verify = require('./Verify');
 /**
  * Register the Webpack entry/output paths.
  *
- * @param {string|array}  entry
+ * @param {string|Array}  entry
  * @param {string} output
  */
 module.exports.js = (entry, output) => {
@@ -35,7 +35,7 @@ module.exports.js = (entry, output) => {
  * Register vendor libs that should be extracted.
  * This helps drastically with long-term caching.
  *
- * @param {array}  libs
+ * @param {Array}  libs
  * @param {string} output
  */
 module.exports.extract = (libs, output) => {
@@ -137,7 +137,7 @@ module.exports.preprocess = (type, src, output, pluginOptions) => {
 /**
  * Combine a collection of files.
  *
- * @param {string|array} src
+ * @param {string|Array} src
  * @param {string}       output
  */
 module.exports.combine = (src, output) => {
@@ -174,7 +174,7 @@ module.exports.copy = (from, to, flatten = true) => {
 /**
  * Minify the provided file.
  *
- * @param {string|array} src
+ * @param {string|Array} src
  */
 module.exports.minify = (src) => {
     output = src.replace(/\.([a-z]{2,})$/i, '.min.$1');
@@ -198,7 +198,7 @@ module.exports.sourceMaps = () => {
 /**
  * Enable compiled file versioning.
  *
- * @param {string|array} files
+ * @param {string|Array} files
  */
 module.exports.version = (files = []) => {
     Mix.versioning = true;

--- a/src/index.js
+++ b/src/index.js
@@ -243,6 +243,18 @@ module.exports.webpackConfig = (config) => {
 
 
 /**
+ * Set Mix-specific options.
+ *
+ * @param {object} options
+ */
+module.exports.options = (options) => {
+    Mix.options = options;
+
+    return this;
+};
+
+
+/**
  * Register a Webpack build event handler.
  *
  * @param {Function} callback

--- a/src/index.js
+++ b/src/index.js
@@ -157,10 +157,14 @@ module.exports.combine = (src, output) => {
  * @param {boolean} flatten
  */
 module.exports.copy = (from, to, flatten = true) => {
-    Mix.copy = (Mix.copy || []).concat({
-        from,
-        to: Mix.Paths.root(to),
-        flatten: flatten
+    Mix.copy = Mix.copy || [];
+
+    [].concat(from).forEach(src => {
+        Mix.copy.push({
+            from: src,
+            to: Mix.Paths.root(to),
+            flatten: flatten
+        });
     });
 
     return this;

--- a/src/index.js
+++ b/src/index.js
@@ -231,6 +231,18 @@ module.exports.setPublicPath = (path) => {
 
 
 /**
+ * Set prefix for generated asset paths
+ *
+ * @param {string} path
+ */
+module.exports.setResourceRoot = (path) => {
+    Mix.resourceRoot = path;
+
+    return this;
+};
+
+
+/**
  * Merge custom config with the provided webpack.config file.
  *
  * @param {object} config

--- a/test/copy.js
+++ b/test/copy.js
@@ -1,0 +1,67 @@
+import test from 'ava';
+import * as mix from '../src/index';
+import File from '../src/File';
+import path from 'path';
+import CopyWebpackPlugin from 'copy-webpack-plugin';
+
+
+test.afterEach(() => mix.config.reset());
+
+test('that it can copy a file to a new location', t => {
+    let from = new File(path.resolve(__dirname, 'from.txt'));
+    let to = path.resolve(__dirname, 'to.txt');
+
+    mix.copy(from.path(), to);
+
+    t.deepEqual([{
+        from: from.path(),
+        to: to,
+        flatten: true
+    }], mix.config.copy);
+});
+
+
+test('that it can copy multiple files to a new location', t => {
+    let from1 = path.resolve(__dirname, 'from1.txt');
+    let from2 = path.resolve(__dirname, 'from2.txt');
+    let to1 = path.resolve(__dirname, 'to1.txt');
+    let to2 = path.resolve(__dirname, 'to2.txt');
+
+    mix.copy(from1, to1);
+    mix.copy(from2, to2);
+
+    t.deepEqual([
+        {
+            from: from1,
+            to: to1,
+            flatten: true
+        },
+        {
+            from: from2,
+            to: to2,
+            flatten: true
+        }
+    ], mix.config.copy);
+});
+
+
+test('that it can copy an array of files to a new location', t => {
+    let from1 = path.resolve(__dirname, 'from1.txt');
+    let from2 = path.resolve(__dirname, 'from2.txt');
+    let to = path.resolve(__dirname, 'to');
+
+    mix.copy([from1, from2], to);
+
+    t.deepEqual([
+        {
+            from: from1,
+            to: to,
+            flatten: true
+        },
+        {
+            from: from2,
+            to: to,
+            flatten: true
+        }
+    ], mix.config.copy);
+});

--- a/test/file.js
+++ b/test/file.js
@@ -63,6 +63,7 @@ test('that it can create a duplicated, versioned file.', t => {
     let versionedFile = file.version();
 
     t.true(File.exists(versionedFile.file));
+    t.is('foo', versionedFile.read());
 
     // Clean up
     file.delete();

--- a/test/file.js
+++ b/test/file.js
@@ -57,25 +57,23 @@ test('that it can rename a file', t => {
 });
 
 
+test('that it can create a duplicated, versioned file.', t => {
+    let file = new File(path.resolve(__dirname, 'file.txt')).write('foo');
+
+    let versionedFile = file.version();
+
+    t.true(File.exists(versionedFile.file));
+
+    // Clean up
+    file.delete();
+    versionedFile.delete();
+});
+
+
 test('that it fetches the versioned file path', t => {
     let versionedPath = new File('path/to/file.js').versionedPath('hash-stub');
 
     t.is('path/to/file.hash-stub.js', versionedPath);
-});
-
-
-test('that it can be copied to a new location', t => {
-    let original = new File(path.resolve(__dirname, 'original.js'));
-    let copied = new File(path.resolve(__dirname, 'copied-original.js'));
-
-    original.write('foobar').copy(copied.path());
-
-    t.true(File.exists(original.path()));
-    t.true(File.exists(copied.path()));
-    t.is('foobar', copied.read());
-
-    original.delete();
-    copied.delete();
 });
 
 

--- a/test/versioning.js
+++ b/test/versioning.js
@@ -22,16 +22,11 @@ test.before(t => {
 
 
 test.beforeEach(() => {
+    let manifest = new Manifest(manifestPath);
+
     version = new Versioning(
-        [], new Manifest(manifestPath), root
+        [], manifest, root
     );
-});
-
-
-test.after.always('cleanup', t => {
-    manifestFile.delete();
-    cssFile.delete();
-    jsFile.delete();
 });
 
 
@@ -39,48 +34,6 @@ test('creates a new versioning instance', t => {
     let manifestPath = root +'/versioning.json';
 
     t.is(version.manifest.path, manifestPath);
-    t.deepEqual(version.files, []);
 });
 
-
-test('it records versioned files', t => {
-    version.record();
-
-    t.deepEqual(version.files, ["fixtures/versionapp.js","fixtures/versionapp.css"]);
-});
-
-
-test('it resets versioned files', t => {
-    version.reset();
-    t.deepEqual(version.files, []);
-});
-
-
-test('that it replaces all old hashed files with new version', t => {
-    // Make sure file exists
-    t.true(File.exists(cssFile.file));
-    t.true(File.exists(jsFile.file));
-
-    // Prune with nothing updated
-    version.prune();
-
-    t.deepEqual(version.files, [
-        "fixtures/versionapp.js",
-        "fixtures/versionapp.css"
-    ]);
-
-    // Fake a manifest.json update
-    delete version.manifest.manifest['app.css'];
-
-    // See if prune works...
-    version.prune();
-    t.deepEqual(version.files, ["fixtures/versionapp.js"]);
-});
-
-
-test('that it fails without a manifest.json', t => {
-    manifestFile.delete();
-    version.reset();
-    version.prune();
-    t.deepEqual(version.files, []);
-});
+// TODO: Test version pruning.


### PR DESCRIPTION
Currently the `publicPath` of image and font resources is hard-coded to `/`. However, it's quite usual, that someone wants the website to work even from a sub-folder, for example `localhost/mypage`. Laravel provides an `asset` helper for it, which generates a fully qualified URL, but because of this setting in Laravel Mix, it becomes meaningless, because resources linked from CSS files won't work anyways.
I propose a solution for giving the ability to the developer to set the resource root used for generated resource locators with `setResourceRoot`. This way, developers don't have to hold a copy of `webpack.config.js` if they want to support sub-folder websites.