### PR TITLE
Fixing JSDoc

### DIFF
--- a/src/Collection.js
+++ b/src/Collection.js
@@ -13,7 +13,7 @@ class Collection {
      * Add a new key-value pair to the collection.
      *
      * @param {string}       name
-     * @param {string|array} files
+     * @param {string|Array} files
      */
     add(name, files) {
         if (! this.items[name]) {
@@ -27,7 +27,7 @@ class Collection {
     /**
      * Get the underlying items for the collection.
      *
-     * @return {array}
+     * @return {Array}
      */
     get() {
         return this.items;

--- a/src/Dispatcher.js
+++ b/src/Dispatcher.js
@@ -10,7 +10,7 @@ class Dispatcher {
     /**
      * Listen for the given event.
      *
-     * @param {string|array}   events
+     * @param {string|Array}   events
      * @param {Function}       handler
      */
     listen(events, handler) {
@@ -26,7 +26,7 @@ class Dispatcher {
      * Trigger all handlers for the given event.
      *
      * @param {string} event
-     * @param {mixed} data
+     * @param {*} data
      */
     fire(event, data) {
         if (! this.events[event]) return false;

--- a/src/Manifest.js
+++ b/src/Manifest.js
@@ -86,7 +86,7 @@ class Manifest {
     /**
      * Append any mix.combine()'d output paths to the manifest.
      *
-     * @param {array} combine
+     * @param {Array} toCombine
      */
     appendCombinedFiles(toCombine) {
         let output = this.preparePath(toCombine.output);

--- a/src/Mix.js
+++ b/src/Mix.js
@@ -129,7 +129,7 @@ class Mix {
     /**
      * Detect if the user desires hot reloading.
      *
-     * @param {bool} force
+     * @param {boolean} force
      */
     detectHotReloading(force = false) {
         let file = new this.File(this.publicPath + '/hot');

--- a/src/Verify.js
+++ b/src/Verify.js
@@ -5,8 +5,8 @@ class Verify {
     /**
      * Verify that the call the mix.js() is valid.
      *
-     * @param {mixed} entry
-     * @param {mixed} output
+     * @param {*} entry
+     * @param {*} output
      */
     static js(entry, output) {
         assert(
@@ -25,7 +25,7 @@ class Verify {
      * Verify that the calls the mix.sass() and mix.less() are valid.
      *
      * @param {string} type
-     * @param {string} entry
+     * @param {string} src
      * @param {string} output
      */
     static preprocessor(type, src, output) {
@@ -44,7 +44,7 @@ class Verify {
     /**
      * Verify that the call the mix.extract() is valid.
      *
-     * @param {array} entry
+     * @param {Array} libs
      */
     static extract(libs) {
         assert(
@@ -57,7 +57,7 @@ class Verify {
     /**
      * Verify that the call the mix.combine() is valid.
      *
-     * @param {array} src
+     * @param {Array} src
      */
     static combine(src) {
         assert(

--- a/src/Versioning.js
+++ b/src/Versioning.js
@@ -6,7 +6,7 @@ class Versioning {
     /**
      * Create a new Versioning instance.
      *
-     * @param {array}  manualFiles
+     * @param {Array}  manualFiles
      * @param {object} manifest
      * @param {string} publicPath
      */

--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,7 @@ let Verify = require('./Verify');
 /**
  * Register the Webpack entry/output paths.
  *
- * @param {string|array}  entry
+ * @param {string|Array}  entry
  * @param {string} output
  */
 module.exports.js = (entry, output) => {
@@ -35,7 +35,7 @@ module.exports.js = (entry, output) => {
  * Register vendor libs that should be extracted.
  * This helps drastically with long-term caching.
  *
- * @param {array}  libs
+ * @param {Array}  libs
  * @param {string} output
  */
 module.exports.extract = (libs, output) => {
@@ -137,7 +137,7 @@ module.exports.preprocess = (type, src, output, pluginOptions) => {
 /**
  * Combine a collection of files.
  *
- * @param {string|array} src
+ * @param {string|Array} src
  * @param {string}       output
  */
 module.exports.combine = (src, output) => {
@@ -174,7 +174,7 @@ module.exports.copy = (from, to, flatten = true) => {
 /**
  * Minify the provided file.
  *
- * @param {string|array} src
+ * @param {string|Array} src
  */
 module.exports.minify = (src) => {
     output = src.replace(/\.([a-z]{2,})$/i, '.min.$1');
@@ -198,7 +198,7 @@ module.exports.sourceMaps = () => {
 /**
  * Enable compiled file versioning.
  *
- * @param {string|array} files
+ * @param {string|Array} files
  */
 module.exports.version = (files = []) => {
     Mix.versioning = true;


### PR DESCRIPTION
- Fixing wrong parameter names.
- `array` is not a type, `Array` is: http://usejsdoc.org/tags-type.html#examples
- Instead of `mixed`, `{*}` should be used: http://usejsdoc.org/tags-param.html#multiple-types-and-repeatable-parameters
- `bool` is not a type, `boolean` is: http://usejsdoc.org/tags-type.html#overview