### PR TITLE
Resolves issue with special characters in dir

### DIFF
--- a/setup/webpack.config.js
+++ b/setup/webpack.config.js
@@ -149,7 +149,7 @@ if (Mix.preprocessors) {
         let sourceMap = Mix.sourcemaps ? '?sourceMap' : '';
 
         module.exports.module.rules.push({
-            test: new RegExp(toCompile.src.path.replace(/\\/g, '\\\\') + '$'),
+            test: new RegExp(toCompile.src.path.replace(/(\s|\(|\))/g,'\\$1').normalize() + '$'),
             use: extractPlugin.extract({
                 fallback: 'style-loader',
                 use: [

--- a/setup/webpack.config.js
+++ b/setup/webpack.config.js
@@ -149,7 +149,7 @@ if (Mix.preprocessors) {
         let sourceMap = Mix.sourcemaps ? '?sourceMap' : '';
 
         module.exports.module.rules.push({
-            test: new RegExp(toCompile.src.path.replace(/(\s|\(|\))/g,'\\$1').normalize() + '$'),
+            test: new RegExp(toCompile.src.path.replace(/\\/g, '\\\\').replace(/(\s|\(|\))/g,'\\$1').normalize() + '$'),
             use: extractPlugin.extract({
                 fallback: 'style-loader',
                 use: [

--- a/setup/webpack.config.js
+++ b/setup/webpack.config.js
@@ -149,7 +149,7 @@ if (Mix.preprocessors) {
         let sourceMap = Mix.sourcemaps ? '?sourceMap' : '';
 
         module.exports.module.rules.push({
-            test: new RegExp(toCompile.src.path.replace(/\\/g, '\\\\').replace(/(\s|\(|\))/g,'\\$1').normalize() + '$'),
+            test: new RegExp(toCompile.src.path.replace(/\\/g, '\\\\').replace(/(\s|\(|\))/g,'\\$1') + '$'),
             use: extractPlugin.extract({
                 fallback: 'style-loader',
                 use: [


### PR DESCRIPTION
Proposing this as a fix for Issue 317 where spaces, ( and ) are not escaped appropriately. In addition, move from a regex expression to a normalize() command to get path structures functional cross platform. Requesting windows user support in confirming normalize() still allows file paths to properly escape