### PR TITLE
Define Mix.options

### DIFF
--- a/src/Mix.js
+++ b/src/Mix.js
@@ -25,6 +25,7 @@ class Mix {
         this.concat = new Concat(this.events);
         this.inProduction = process.env.NODE_ENV === 'production';
         this.publicPath = './';
+        this.options = {};
     }
 
 
@@ -190,6 +191,7 @@ class Mix {
         this.events = new Dispatcher;
         this.concat = new Concat(this.events);
         this.copy = [];
+        this.options = {};
 
         return this;
     }


### PR DESCRIPTION
`Mix.options` currently only exists, if `Mix.options()` is called in `webpack.mix.js`. However, if someone wants to use the default settings, they will get `TypeError: Cannot read property 'extractVueStyles' of undefined`, therefore `Mix.options` should be defined as default.