### PR TITLE
Fix broken test by adding assertion that will properly throw .. 

### DIFF
--- a/src/Verify.js
+++ b/src/Verify.js
@@ -64,6 +64,13 @@ class Verify {
             Array.isArray(src),
             'mix.combine() requires an array as its first parameter.'
         );
+
+        Array.from(src).map(file => {
+            assert(
+                File.exists(file),
+                'mix.combine() requires an array of paths to files that already exist.'
+            );
+        });
     }
 }
 


### PR DESCRIPTION
.. if paths in combine() params go to files that do not exist.