### PR TITLE
add a mock entry for no mix.js() config

### DIFF
--- a/src/EntryBuilder.js
+++ b/src/EntryBuilder.js
@@ -54,25 +54,9 @@ class EntryBuilder {
      * user hasn't called mix.js().
      */
     addTemporaryScript() {
-        let file = new this.mix.File('mix-entry.js').write('');
+        let file = new this.mix.File(path.resolve(__dirname, 'mock-entry.js'));
 
         this.entry.add('mix', file.path());
-
-        this.mix.events.listen('build', stats => {
-            file.delete();
-
-            // If no mix.js() call was requested, we'll also need
-            // to delete the output script for the user. Since we
-            // won't know the exact name, we'll hunt it down.
-            let temporaryOutputFile = stats.toJson()
-                .assets
-                .find(asset => asset.chunkNames.includes('mix'))
-                .name;
-
-            this.mix.File.find(
-                path.join(this.mix.output().path, temporaryOutputFile)
-            ).delete();
-        });
 
         return this;
     }

--- a/src/EntryBuilder.js
+++ b/src/EntryBuilder.js
@@ -58,6 +58,20 @@ class EntryBuilder {
 
         this.entry.add('mix', file.path());
 
+        this.mix.events.listen('build', stats => {
+            // If no mix.js() call was requested, we'll also need
+            // to delete the output script for the user. Since we
+            // won't know the exact name, we'll hunt it down.
+            let temporaryOutputFile = stats.toJson()
+                .assets
+                .find(asset => asset.chunkNames.includes('mix'))
+                .name;
+
+            this.mix.File.find(
+                path.join(this.mix.output().path, temporaryOutputFile)
+            ).delete();
+        });
+
         return this;
     }
 


### PR DESCRIPTION
#359 
This error was because of removing `mix-entry.js`  immediately after the first building in watch mode, so the next building after source code changed get crashed if no `mix.js()` called.

Add a `mock-entry.js` file in laravel-mix src for this scenario, instead of generating a temporary entry file and delete it after built.
