### PR TITLE
Update friendly-errors-webpack-plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "css-loader": "^0.14.5",
     "extract-text-webpack-plugin": "^2.0.0-rc.3",
     "file-loader": "^0.9.0",
-    "friendly-errors-webpack-plugin": "^1.1.3",
+    "friendly-errors-webpack-plugin": "^1.2.0",
     "fs": "0.0.1-security",
     "html-loader": "^0.4.4",
     "less": "^2.7.1",


### PR DESCRIPTION
Haven't tested it. Just noticed that they tagged a new version a few hours ago. Few small changes, but mostly fixes eslint messages.

Comparison: https://github.com/geowarin/friendly-errors-webpack-plugin/compare/v1.1.3...v1.2.0