### PR TITLE
Fix documentation about Laravel `mix` helper

### DIFF
--- a/docs/extract.md
+++ b/docs/extract.md
@@ -29,8 +29,6 @@ Once you run Webpack to compile your code, you'll find three new files. You may 
 
 In effect, we pay a small HTTP request penalty, in exchange for improved long-term caching.
 
-> **Laravel Users:** You alternatively have access to a `mix('js/app.js')` function that will dynamically create these script tag for you.
-
 ### What's That Manifest File?
 
 Webpack compiles with a small bit of run-time code, to assist with its job. When not using `mix.extract()`, this code is invisible to you, and lives inside your bundle file. However, if we want to split our code and allow for long-term caching, that runtime code needs to live somewhere. As such, mix will extract it to its own file as well. This way, both your vendor and manifest files can be cached as long as possible.


### PR DESCRIPTION
The Laravel `mix` helper [currently](https://github.com/laravel/framework/blob/48e6c096c3d156899db1619fe015b1fa8f020d0e/src/Illuminate/Foundation/helpers.php#L561) *does not* actually build these script tags dynamically, so the docs shouldn't say that it does.