### PR TITLE
Updated FAQs to make --watch-poll instructions clearer

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -26,7 +26,7 @@ It's highly recommended that you add the following NPM scripts to your `package.
 
 ### I'm using a VM, and Webpack isn't picking up my file changes.
 
-If you're running `npm run dev` through a VM, you may find that file changes are not picked up by Webpack. If that's the case, update your NPM script to use the `--watch-poll` flag, rather than `--watch`. Like this:
+If you're running `npm run dev` through a VM, you may find that file changes are not picked up by Webpack. If that's the case, update your NPM script to use the `--watch-poll` flag, in addition to the `--watch` flag. Like this:
 
 ```js
 "scripts": {


### PR DESCRIPTION
At a quick glance it implies you need to use `--watch-poll` *instead* of `--watch`, but you actually need to use them together, so I made that clearer for anyone else who (like me) missed it the first time.