### PR TITLE
Allow for BrowserSync to inject css files without reloading the page.

### DIFF
--- a/setup/webpack.config.js
+++ b/setup/webpack.config.js
@@ -331,18 +331,22 @@ module.exports.plugins = (module.exports.plugins || []).concat([
 
 if (Mix.browserSync) {
     module.exports.plugins.push(
-        new plugins.BrowserSyncPlugin(Object.assign({
-            host: 'localhost',
-            port: 3000,
-            proxy: 'app.dev',
-            files: [
-                'app/**/*.php',
-                'resources/views/**/*.php',
-                'public/mix-manifest.json',
-                'public/css/**/*.css',
-                'public/js/**/*.js'
-            ]
-        }, Mix.browserSync))
+        new plugins.BrowserSyncPlugin(
+            Object.assign({
+                host: 'localhost',
+                port: 3000,
+                proxy: 'app.dev',
+                files: [
+                    'app/**/*.php',
+                    'resources/views/**/*.php',
+                    'public/js/**/*.js',
+                    'public/css/**/*.css'
+                ]
+            }, Mix.browserSync),
+            {
+                reload: false
+            }
+        )
     );
 }
 


### PR DESCRIPTION
This would close issue #413 - the Webpack BrowserSync plugin accepts a second argument that is an object of options for the plugin itself, not for BrowserSync. The important option here is `reload`, if it is set to false the plugin allows for injection rather than hard reloading.

It is also important to remove the matcher for mix-manifest.json. Even with reload set to false, files listed in `files` that change and are not deemed injectable will trigger a hard reload.