### PR TITLE
Fix file extension of compiled ".sass" file.

### DIFF
--- a/docs/basic-example.md
+++ b/docs/basic-example.md
@@ -13,7 +13,7 @@ mix.sass('src/app.sass', 'dist')
 
 Done. Simple, right?
 
-1. Compile the Sass file, `./src/app.sass`, to `./dist/app.sass`
+1. Compile the Sass file, `./src/app.sass`, to `./dist/app.css`
 2. Bundle all JavaScript \(and any required modules\) at `./src/app.js` to `./dist/app.js`.
 
 With this configuration in place, we may trigger Webpack from the command line: `node_modules/.bin/webpack`.


### PR DESCRIPTION
`.sass` should be `.css` once it is compiled by webpack.