### PR TITLE
Support for vendor asset subfolders (Fixes #286)

### DIFF
--- a/setup/webpack.config.js
+++ b/setup/webpack.config.js
@@ -143,7 +143,7 @@ module.exports.module = {
             options: {
                 name: path => {
                     if (!/node_modules|bower_components/.test(path)) {
-                        return 'fonts/[name].[ext]?[hash]';
+                        return 'images/[name].[ext]?[hash]';
                     }
 
                     return 'images/vendor/' + path.replace(/((.*(node_modules|bower_components))|images|image|img|assets)(\/|\\)/g, '') + '?[hash]';

--- a/setup/webpack.config.js
+++ b/setup/webpack.config.js
@@ -141,7 +141,13 @@ module.exports.module = {
             test: /\.(png|jpe?g|gif)$/,
             loader: 'file-loader',
             options: {
-                name: 'images/[name].[ext]?[hash]',
+                name: path => {
+                    if (!/node_modules|bower_components/.test(path)) {
+                        return 'fonts/[name].[ext]?[hash]';
+                    }
+
+                    return 'images/' + path.replace(/((.*(node_modules|bower_components))|images|image|img|assets)(\/|\\)/g, '') + '?[hash]';
+                },
                 publicPath: Mix.resourceRoot
             }
         },
@@ -150,7 +156,13 @@ module.exports.module = {
             test: /\.(woff2?|ttf|eot|svg|otf)$/,
             loader: 'file-loader',
             options: {
-                name: 'fonts/[name].[ext]?[hash]',
+                name: path => {
+                    if (!/node_modules|bower_components/.test(path)) {
+                        return 'fonts/[name].[ext]?[hash]';
+                    }
+
+                    return 'fonts/' + path.replace(/((.*(node_modules|bower_components))|fonts|font|assets)(\/|\\)/g, '') + '?[hash]';
+                },
                 publicPath: Mix.resourceRoot
             }
         },

--- a/setup/webpack.config.js
+++ b/setup/webpack.config.js
@@ -146,7 +146,7 @@ module.exports.module = {
                         return 'fonts/[name].[ext]?[hash]';
                     }
 
-                    return 'images/' + path.replace(/((.*(node_modules|bower_components))|images|image|img|assets)(\/|\\)/g, '') + '?[hash]';
+                    return 'images/vendor/' + path.replace(/((.*(node_modules|bower_components))|images|image|img|assets)(\/|\\)/g, '') + '?[hash]';
                 },
                 publicPath: Mix.resourceRoot
             }
@@ -161,7 +161,7 @@ module.exports.module = {
                         return 'fonts/[name].[ext]?[hash]';
                     }
 
-                    return 'fonts/' + path.replace(/((.*(node_modules|bower_components))|fonts|font|assets)(\/|\\)/g, '') + '?[hash]';
+                    return 'fonts/vendor/' + path.replace(/((.*(node_modules|bower_components))|fonts|font|assets)(\/|\\)/g, '') + '?[hash]';
                 },
                 publicPath: Mix.resourceRoot
             }


### PR DESCRIPTION
Currently all assets are just dumped into `fonts` and `images`. However, multiple vendor packages can use different `loading.gif` files for example, which are being overridden by each other, so as a result only one of the packages will work as intended (fixes #286).

To solve this problem, first I have updated Webpack's loader-utils to give us the ability to change the result filename any way we want (https://github.com/webpack/loader-utils/pull/59), and with its help in this PR I propose generating a relatively logical folder structure for vendor assets starting from the name of the package, ignoring image, font and asset folders. For example:

- node_modules/test/images/loading.gif => images/vendor/test/loading.gif
- bower_components/awesome/assets/font/glyph/glyph.otf => fonts/vendor/awesome/glyph/glyph.otf