### PR TITLE
Fix minify when processCssUrls option is false

### DIFF
--- a/src/Preprocessors/Preprocessor.js
+++ b/src/Preprocessors/Preprocessor.js
@@ -68,7 +68,7 @@ class Preprocessor {
         let sourceMap = Mix.sourcemaps ? '?sourceMap' : '';
 
         return [
-            { loader: (Mix.options.processCssUrls ? 'css-loader' : 'raw-loader') + sourceMap },
+            { loader: 'css-loader' + sourceMap },
             { loader: 'postcss-loader' + sourceMap }
         ];
     }


### PR DESCRIPTION
I have the problem with minifying css if processCssUrls option is false.

Minify is not working because raw-loader (which use in this case) does not support minify. Can we use css-loader in this case too?