### PR TITLE
fix(readme): switch webpack to proper "w" casing

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
 ## Introduction
 
-Laravel Mix provides a clean, fluent API for defining basic Webpack build steps for your Laravel application. Mix supports several common CSS and JavaScript pre-processors.
+Laravel Mix provides a clean, fluent API for defining basic [webpack](http://github.com/webpack/webpack) build steps for your Laravel application. Mix supports several common CSS and JavaScript pre-processors.
 
 If you've ever been confused about how to get started with module bundling and asset compilation, you will love Laravel Mix!
 


### PR DESCRIPTION
Per webpack brand [guidelines](http://github.com/webpack/media), the "w" in webpack is always lowercase. So thought I'd drop a little PR here and then also have that name link to our repo (cause why not we love links!)