### PR TITLE
Allow sourceMaps while processCssUrls is disabled

### DIFF
--- a/src/Api.js
+++ b/src/Api.js
@@ -285,7 +285,7 @@ class Api {
      * Enable sourcemap support.
      */
     sourceMaps() {
-        this.Mix.sourcemaps = (this.Mix.inProduction ? false : '#inline-source-map');
+        this.Mix.sourcemaps = (this.Mix.inProduction ? false : 'source-map');
 
         return this;
     };

--- a/src/Preprocessors/Sass.js
+++ b/src/Preprocessors/Sass.js
@@ -6,12 +6,12 @@ class Sass extends Preprocessor {
      */
     loaders(sourceMaps) {
         let loaders = [
-            { loader: 'sass-loader', options: this.sassPluginOptions() }
+            { loader: 'sass-loader' + (sourceMaps ? '?sourceMap' : ''), options: this.sassPluginOptions() }
         ];
 
         if (this.mixOptions.processCssUrls) {
             loaders.unshift(
-                { loader: 'resolve-url-loader' + (sourceMaps ? '?sourceMap' : '') }
+                { loader: 'resolve-url-loader' }
             );
         }
 


### PR DESCRIPTION
Fixes slow performance issue e.g build bootstrap-sass

https://github.com/JeffreyWay/laravel-mix/issues/49