### PR TITLE
Fix in publicPath output

### DIFF
--- a/src/Mix.js
+++ b/src/Mix.js
@@ -80,7 +80,7 @@ class Mix {
             path: this.options.hmr ? '/' : this.options.publicPath,
             filename: filename,
             chunkFilename: chunkFilename,
-            publicPath: this.options.hmr ? 'http://localhost:8080' : ''
+            publicPath: this.options.hmr ? 'http://localhost:8080' : './'
         };
     }
 


### PR DESCRIPTION
When compiling with webpack, this was outputing to the root directory (_eg. localhost/_).
If you have a custom directory (_eg. localhost/path/to/my/project_), then it won't work. 
So, it's better to output to the current working directory.