### PR TITLE
Add clearConsole option for friendly errors output

### DIFF
--- a/setup/webpack.config.js
+++ b/setup/webpack.config.js
@@ -302,7 +302,7 @@ plugins.push(
         jquery: 'jquery'
     }),
 
-    new webpackPlugins.FriendlyErrorsWebpackPlugin(),
+    new webpackPlugins.FriendlyErrorsWebpackPlugin({ clearConsole: Mix.options.clearConsole }),
 
     new webpackPlugins.StatsWriterPlugin({
         filename: 'mix-manifest.json',

--- a/src/Options.js
+++ b/src/Options.js
@@ -130,6 +130,17 @@ module.exports = {
 
 
     /**
+     * Determine if Mix should ask the friendly errors plugin to
+     * clear the console before outputting the results or not.
+     *
+     * https://github.com/geowarin/friendly-errors-webpack-plugin#options
+     *
+     * @type {Boolean}
+     */
+    clearConsole: true,
+
+
+    /**
      * Merge the given options with the current defaults.
      *
      * @param {object} options


### PR DESCRIPTION
Adds in an option to toggle the `clearConsole` option on the `FriendlyErrorsWebpackPlugin`.

This changes the console output so rather than clearing the console before printing the output, it simply prints the output... or in pictures:

`clearConsole: true` (default):

![image](https://cloud.githubusercontent.com/assets/897369/24020014/966ba99a-0aee-11e7-882b-b6862ba9ce36.png)

`clearConsole: false`:

![image](https://cloud.githubusercontent.com/assets/897369/24020079/d088aba0-0aee-11e7-9c69-8dd9453ef3f8.png)
