### PR TITLE
cross-env 3.2 breaks folder structure

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "clean-css": "^4.0.7",
     "concatenate": "0.0.2",
     "copy-webpack-plugin": "^4.0.1",
-    "cross-env": "^3.1.3",
+    "cross-env": "3.1.3",
     "css-loader": "^0.14.5",
     "extract-text-webpack-plugin": "^2.0.0-rc.3",
     "file-loader": "^0.9.0",


### PR DESCRIPTION
because cross-env 3.2 no longer has a "bin" directory in root, npm run dev fails in Laravel 5.4