### PR TITLE
Fix an issue where the cross-env binary wasn't found

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "clean-css": "^4.0.7",
     "concatenate": "0.0.2",
     "copy-webpack-plugin": "^4.0.1",
-    "cross-env": "^3.1.3",
+    "cross-env": "~3.1.3",
     "css-loader": "^0.14.5",
     "extract-text-webpack-plugin": "^2.0.0-rc.3",
     "file-loader": "^0.9.0",


### PR DESCRIPTION
A project I work on requires Laravel Mix, whenever I try to run `npm install`, I get the following error:

```
Error: Cannot find module '/path/to/the/project/node_modules/cross-env/bin/cross-env.js'
    at Function.Module._resolveFilename (module.js:470:15)
    at Function.Module._load (module.js:418:25)
    at Module.runMain (module.js:605:10)
    at run (bootstrap_node.js:425:7)
    at startup (bootstrap_node.js:146:9)
    at bootstrap_node.js:540:3
```

Laravel Mix seems to use cross-env's command during its installation process but the `bin` directory has been removed from cross-env since v3.2.0.

Until Laravel Mix is updated to work with cross-env v3.2.*, I suggest to change version requirement from `^3.1.3` to `~3.1.3`, which fixes the issue.