### PR TITLE
Simple tasks implementation

### DIFF
--- a/setup/webpack.config.js
+++ b/setup/webpack.config.js
@@ -4,430 +4,437 @@ let webpack = require('webpack');
 let Mix = require('laravel-mix').config;
 let webpackPlugins = require('laravel-mix').plugins;
 
-/*
- |--------------------------------------------------------------------------
- | Mix Initialization
- |--------------------------------------------------------------------------
- |
- | As our first step, we'll require the project's Laravel Mix file
- | and record the user's requested compilation and build steps.
- | Once those steps have been recorded, we may get to work.
- |
- */
+module.exports = (env = {}) => {
 
-Mix.initialize();
+    let config = {};
 
+    /*
+     |--------------------------------------------------------------------------
+     | Mix Initialization
+     |--------------------------------------------------------------------------
+     |
+     | As our first step, we'll require the project's Laravel Mix file
+     | and record the user's requested compilation and build steps.
+     | Once those steps have been recorded, we may get to work.
+     |
+     */
 
-
-/*
- |--------------------------------------------------------------------------
- | Webpack Context
- |--------------------------------------------------------------------------
- |
- | This prop will determine the appropriate context, when running Webpack.
- | Since you have the option of publishing this webpack.config.js file
- | to your project root, we will dynamically set the path for you.
- |
- */
-
-module.exports.context = Mix.Paths.root();
+    Mix.initialize(env);
 
 
 
-/*
- |--------------------------------------------------------------------------
- | Webpack Entry
- |--------------------------------------------------------------------------
- |
- | We'll first specify the entry point for Webpack. By default, we'll
- | assume a single bundled file, but you may call Mix.extract()
- | to make a separate bundle specifically for vendor libraries.
- |
- */
+    /*
+     |--------------------------------------------------------------------------
+     | Webpack Context
+     |--------------------------------------------------------------------------
+     |
+     | This prop will determine the appropriate context, when running Webpack.
+     | Since you have the option of publishing this webpack.config.js file
+     | to your project root, we will dynamically set the path for you.
+     |
+     */
 
-module.exports.entry = Mix.entry().get();
-
-
-
-/*
- |--------------------------------------------------------------------------
- | Webpack Output
- |--------------------------------------------------------------------------
- |
- | Webpack naturally requires us to specify our desired output path and
- | file name. We'll simply echo what you passed to with Mix.js().
- | Note that, for Mix.version(), we'll properly hash the file.
- |
- */
-
-module.exports.output = Mix.output();
+    config.context = Mix.Paths.root();
 
 
 
-/*
- |--------------------------------------------------------------------------
- | Rules
- |--------------------------------------------------------------------------
- |
- | Webpack rules allow us to register any number of loaders and options.
- | Out of the box, we'll provide a handful to get you up and running
- | as quickly as possible, though feel free to add to this list.
- |
- */
+    /*
+     |--------------------------------------------------------------------------
+     | Webpack Entry
+     |--------------------------------------------------------------------------
+     |
+     | We'll first specify the entry point for Webpack. By default, we'll
+     | assume a single bundled file, but you may call Mix.extract()
+     | to make a separate bundle specifically for vendor libraries.
+     |
+     */
 
-let plugins = [];
+    config.entry = Mix.entry().get();
 
-if (Mix.options.extractVueStyles) {
-    var vueExtractTextPlugin = Mix.vueExtractTextPlugin();
 
-    plugins.push(vueExtractTextPlugin);
-}
 
-let rules = [
-    {
-        test: /\.vue$/,
-        loader: 'vue-loader',
-        options: {
-            loaders: Mix.options.extractVueStyles ? {
-                js: 'babel-loader' + Mix.babelConfig(),
-                scss: vueExtractTextPlugin.extract({
-                    use: 'css-loader!sass-loader',
-                    fallback: 'vue-style-loader'
-                }),
-                sass: vueExtractTextPlugin.extract({
-                    use: 'css-loader!sass-loader?indentedSyntax',
-                    fallback: 'vue-style-loader'
-                }),
-                stylus: vueExtractTextPlugin.extract({
-                    use: 'css-loader!stylus-loader?paths[]=node_modules',
-                    fallback: 'vue-style-loader'
-                }),
-                css: vueExtractTextPlugin.extract({
-                    use: 'css-loader',
-                    fallback: 'vue-style-loader'
-                })
-            }: {
-                js: 'babel-loader' + Mix.babelConfig(),
-                scss: 'vue-style-loader!css-loader!sass-loader',
-                sass: 'vue-style-loader!css-loader!sass-loader?indentedSyntax',
-                stylus: 'vue-style-loader!css-loader!stylus-loader?paths[]=node_modules'
-            },
+    /*
+     |--------------------------------------------------------------------------
+     | Webpack Output
+     |--------------------------------------------------------------------------
+     |
+     | Webpack naturally requires us to specify our desired output path and
+     | file name. We'll simply echo what you passed to with Mix.js().
+     | Note that, for Mix.version(), we'll properly hash the file.
+     |
+     */
 
-            postcss: Mix.options.postCss
-        }
-    },
+    config.output = Mix.output();
 
-    {
-        test: /\.jsx?$/,
-        exclude: /(node_modules|bower_components)/,
-        loader: 'babel-loader' + Mix.babelConfig()
-    },
 
-    {
-        test: /\.css$/,
-        loaders: ['style-loader', 'css-loader']
-    },
 
-    {
-        test: /\.s[ac]ss$/,
-        include: /node_modules/,
-        loaders: ['style-loader', 'css-loader', 'sass-loader']
-    },
+    /*
+     |--------------------------------------------------------------------------
+     | Rules
+     |--------------------------------------------------------------------------
+     |
+     | Webpack rules allow us to register any number of loaders and options.
+     | Out of the box, we'll provide a handful to get you up and running
+     | as quickly as possible, though feel free to add to this list.
+     |
+     */
 
-    {
-        test: /\.html$/,
-        loaders: ['html-loader']
-    },
+    let plugins = [];
 
-    {
-        test: /\.(png|jpe?g|gif)$/,
-        loaders: [
-            {
-                loader: 'file-loader',
-                options: {
-                    name: path => {
-                        if (! /node_modules|bower_components/.test(path)) {
-                            return 'images/[name].[ext]?[hash]';
-                        }
+    if (Mix.options.extractVueStyles) {
+        var vueExtractTextPlugin = Mix.vueExtractTextPlugin();
 
-                        return 'images/vendor/' + path
+        plugins.push(vueExtractTextPlugin);
+    }
+
+    let rules = [
+        {
+            test: /\.vue$/,
+            loader: 'vue-loader',
+            options: {
+                loaders: Mix.options.extractVueStyles ? {
+                        js: 'babel-loader' + Mix.babelConfig(),
+                        scss: vueExtractTextPlugin.extract({
+                            use: 'css-loader!sass-loader',
+                            fallback: 'vue-style-loader'
+                        }),
+                        sass: vueExtractTextPlugin.extract({
+                            use: 'css-loader!sass-loader?indentedSyntax',
+                            fallback: 'vue-style-loader'
+                        }),
+                        stylus: vueExtractTextPlugin.extract({
+                            use: 'css-loader!stylus-loader?paths[]=node_modules',
+                            fallback: 'vue-style-loader'
+                        }),
+                        css: vueExtractTextPlugin.extract({
+                            use: 'css-loader',
+                            fallback: 'vue-style-loader'
+                        })
+                    }: {
+                        js: 'babel-loader' + Mix.babelConfig(),
+                        scss: 'vue-style-loader!css-loader!sass-loader',
+                        sass: 'vue-style-loader!css-loader!sass-loader?indentedSyntax',
+                        stylus: 'vue-style-loader!css-loader!stylus-loader?paths[]=node_modules'
+                    },
+
+                postcss: Mix.options.postCss
+            }
+        },
+
+        {
+            test: /\.jsx?$/,
+            exclude: /(node_modules|bower_components)/,
+            loader: 'babel-loader' + Mix.babelConfig()
+        },
+
+        {
+            test: /\.css$/,
+            loaders: ['style-loader', 'css-loader']
+        },
+
+        {
+            test: /\.s[ac]ss$/,
+            include: /node_modules/,
+            loaders: ['style-loader', 'css-loader', 'sass-loader']
+        },
+
+        {
+            test: /\.html$/,
+            loaders: ['html-loader']
+        },
+
+        {
+            test: /\.(png|jpe?g|gif)$/,
+            loaders: [
+                {
+                    loader: 'file-loader',
+                    options: {
+                        name: path => {
+                            if (! /node_modules|bower_components/.test(path)) {
+                                return 'images/[name].[ext]?[hash]';
+                            }
+
+                            return 'images/vendor/' + path
+                                    .replace(/\\/g, '/')
+                                    .replace(
+                                        /((.*(node_modules|bower_components))|images|image|img|assets)\//g, ''
+                                    ) + '?[hash]';
+                        },
+                        publicPath: Mix.options.resourceRoot
+                    }
+                },
+                'img-loader'
+            ]
+        },
+
+        {
+            test: /\.(woff2?|ttf|eot|svg|otf)$/,
+            loader: 'file-loader',
+            options: {
+                name: path => {
+                    if (! /node_modules|bower_components/.test(path)) {
+                        return 'fonts/[name].[ext]?[hash]';
+                    }
+
+                    return 'fonts/vendor/' + path
                             .replace(/\\/g, '/')
                             .replace(
-                                /((.*(node_modules|bower_components))|images|image|img|assets)\//g, ''
+                                /((.*(node_modules|bower_components))|fonts|font|assets)\//g, ''
                             ) + '?[hash]';
-                    },
-                    publicPath: Mix.options.resourceRoot
-                }
-            },
-            'img-loader'
-        ]
-    },
-
-    {
-        test: /\.(woff2?|ttf|eot|svg|otf)$/,
-        loader: 'file-loader',
-        options: {
-            name: path => {
-                if (! /node_modules|bower_components/.test(path)) {
-                    return 'fonts/[name].[ext]?[hash]';
-                }
-
-                return 'fonts/vendor/' + path
-                    .replace(/\\/g, '/')
-                    .replace(
-                        /((.*(node_modules|bower_components))|fonts|font|assets)\//g, ''
-                    ) + '?[hash]';
-            },
-            publicPath: Mix.options.resourceRoot
-        }
-    },
-
-    {
-        test: /\.(cur|ani)$/,
-        loader: 'file-loader',
-        options: {
-            name: '[name].[ext]?[hash]',
-            publicPath: Mix.options.resourceRoot
-        }
-    }
-];
-
-if (Mix.preprocessors) {
-    Mix.preprocessors.forEach(preprocessor => {
-        rules.push(preprocessor.rules());
-
-        plugins.push(preprocessor.extractPlugin);
-    });
-}
-
-module.exports.module = { rules };
-
-
-
-/*
- |--------------------------------------------------------------------------
- | Resolve
- |--------------------------------------------------------------------------
- |
- | Here, we may set any options/aliases that affect Webpack's resolving
- | of modules. To begin, we will provide the necessary Vue alias to
- | load the Vue common library. You may delete this, if needed.
- |
- */
-
-module.exports.resolve = {
-    extensions: ['*', '.js', '.jsx', '.vue'],
-
-    alias: {
-        'vue$': 'vue/dist/vue.common.js'
-    }
-};
-
-
-
-/*
- |--------------------------------------------------------------------------
- | Stats
- |--------------------------------------------------------------------------
- |
- | By default, Webpack spits a lot of information out to the terminal,
- | each you time you compile. Let's keep things a bit more minimal
- | and hide a few of those bits and pieces. Adjust as you wish.
- |
- */
-
-module.exports.stats = {
-    hash: false,
-    version: false,
-    timings: false,
-    children: false,
-    errors: false
-};
-
-process.noDeprecation = true;
-
-module.exports.performance = { hints: false };
-
-
-
-/*
- |--------------------------------------------------------------------------
- | Devtool
- |--------------------------------------------------------------------------
- |
- | Sourcemaps allow us to access our original source code within the
- | browser, even if we're serving a bundled script or stylesheet.
- | You may activate sourcemaps, by adding Mix.sourceMaps().
- |
- */
-
-module.exports.devtool = Mix.options.sourcemaps;
-
-
-
-/*
- |--------------------------------------------------------------------------
- | Webpack Dev Server Configuration
- |--------------------------------------------------------------------------
- |
- | If you want to use that flashy hot module replacement feature, then
- | we've got you covered. Here, we'll set some basic initial config
- | for the Node server. You very likely won't want to edit this.
- |
- */
-module.exports.devServer = {
-    historyApiFallback: true,
-    noInfo: true,
-    compress: true,
-    quiet: true
-};
-
-
-
-/*
- |--------------------------------------------------------------------------
- | Plugins
- |--------------------------------------------------------------------------
- |
- | Lastly, we'll register a number of plugins to extend and configure
- | Webpack. To get you started, we've included a handful of useful
- | extensions, for versioning, OS notifications, and much more.
- |
- */
-
-plugins.push(
-    new webpack.ProvidePlugin(Mix.autoload || {}),
-
-    new webpackPlugins.FriendlyErrorsWebpackPlugin({ clearConsole: Mix.options.clearConsole }),
-
-    new webpackPlugins.StatsWriterPlugin({
-        filename: 'mix-manifest.json',
-        transform: Mix.manifest.transform.bind(Mix.manifest),
-    }),
-
-    new webpack.LoaderOptionsPlugin({
-        minimize: Mix.inProduction,
-        options: {
-            postcss: Mix.options.postCss,
-            context: __dirname,
-            output: { path: './' }
-        }
-    })
-);
-
-if (Mix.browserSync) {
-    plugins.push(
-        new webpackPlugins.BrowserSyncPlugin(
-            Object.assign({
-                host: 'localhost',
-                port: 3000,
-                proxy: 'app.dev',
-                files: [
-                    'app/**/*.php',
-                    'resources/views/**/*.php',
-                    'public/js/**/*.js',
-                    'public/css/**/*.css'
-                ]
-            }, Mix.browserSync),
-            {
-                reload: false
+                },
+                publicPath: Mix.options.resourceRoot
             }
+        },
+
+        {
+            test: /\.(cur|ani)$/,
+            loader: 'file-loader',
+            options: {
+                name: '[name].[ext]?[hash]',
+                publicPath: Mix.options.resourceRoot
+            }
+        }
+    ];
+
+    if (Mix.preprocessors) {
+        Mix.preprocessors.forEach(preprocessor => {
+            rules.push(preprocessor.rules());
+
+            plugins.push(preprocessor.extractPlugin);
+        });
+    }
+
+    config.module = { rules };
+
+
+
+    /*
+     |--------------------------------------------------------------------------
+     | Resolve
+     |--------------------------------------------------------------------------
+     |
+     | Here, we may set any options/aliases that affect Webpack's resolving
+     | of modules. To begin, we will provide the necessary Vue alias to
+     | load the Vue common library. You may delete this, if needed.
+     |
+     */
+
+    config.resolve = {
+        extensions: ['*', '.js', '.jsx', '.vue'],
+
+        alias: {
+            'vue$': 'vue/dist/vue.common.js'
+        }
+    };
+
+
+
+    /*
+     |--------------------------------------------------------------------------
+     | Stats
+     |--------------------------------------------------------------------------
+     |
+     | By default, Webpack spits a lot of information out to the terminal,
+     | each you time you compile. Let's keep things a bit more minimal
+     | and hide a few of those bits and pieces. Adjust as you wish.
+     |
+     */
+
+    config.stats = {
+        hash: false,
+        version: false,
+        timings: false,
+        children: false,
+        errors: false
+    };
+
+    process.noDeprecation = true;
+
+    config.performance = { hints: false };
+
+
+
+    /*
+     |--------------------------------------------------------------------------
+     | Devtool
+     |--------------------------------------------------------------------------
+     |
+     | Sourcemaps allow us to access our original source code within the
+     | browser, even if we're serving a bundled script or stylesheet.
+     | You may activate sourcemaps, by adding Mix.sourceMaps().
+     |
+     */
+
+    config.devtool = Mix.options.sourcemaps;
+
+
+
+    /*
+     |--------------------------------------------------------------------------
+     | Webpack Dev Server Configuration
+     |--------------------------------------------------------------------------
+     |
+     | If you want to use that flashy hot module replacement feature, then
+     | we've got you covered. Here, we'll set some basic initial config
+     | for the Node server. You very likely won't want to edit this.
+     |
+     */
+    config.devServer = {
+        historyApiFallback: true,
+        noInfo: true,
+        compress: true,
+        quiet: true
+    };
+
+
+
+    /*
+     |--------------------------------------------------------------------------
+     | Plugins
+     |--------------------------------------------------------------------------
+     |
+     | Lastly, we'll register a number of plugins to extend and configure
+     | Webpack. To get you started, we've included a handful of useful
+     | extensions, for versioning, OS notifications, and much more.
+     |
+     */
+
+    plugins.push(
+        new webpack.ProvidePlugin(Mix.autoload || {}),
+
+        new webpackPlugins.FriendlyErrorsWebpackPlugin({ clearConsole: Mix.options.clearConsole }),
+
+        new webpackPlugins.StatsWriterPlugin({
+            filename: 'mix-manifest.json',
+            transform: Mix.manifest.transform.bind(Mix.manifest),
+        }),
+
+        new webpack.LoaderOptionsPlugin({
+            minimize: Mix.inProduction,
+            options: {
+                postcss: Mix.options.postCss,
+                context: __dirname,
+                output: { path: './' }
+            }
+        })
+    );
+
+    if (Mix.browserSync) {
+        plugins.push(
+            new webpackPlugins.BrowserSyncPlugin(
+                Object.assign({
+                    host: 'localhost',
+                    port: 3000,
+                    proxy: 'app.dev',
+                    files: [
+                        'app/**/*.php',
+                        'resources/views/**/*.php',
+                        'public/js/**/*.js',
+                        'public/css/**/*.css'
+                    ]
+                }, Mix.browserSync),
+                {
+                    reload: false
+                }
+            )
+        );
+    }
+
+    if (Mix.options.notifications) {
+        plugins.push(
+            new webpackPlugins.WebpackNotifierPlugin({
+                title: 'Laravel Mix',
+                alwaysNotify: true,
+                contentImage: Mix.Paths.root('node_modules/laravel-mix/icons/laravel.png')
+            })
+        );
+    }
+
+    if (Mix.copy) {
+        Mix.copy.forEach(copy => {
+            plugins.push(
+                new webpackPlugins.CopyWebpackPlugin([copy])
+            );
+        });
+    }
+
+    if (Mix.entry().hasExtractions()) {
+        plugins.push(
+            new webpack.optimize.CommonsChunkPlugin({
+                names: Mix.entry().getExtractions(),
+                minChunks: Infinity
+            })
+        );
+    }
+
+    if (Mix.options.versioning) {
+        plugins.push(
+            new webpack[Mix.inProduction ? 'HashedModuleIdsPlugin': 'NamedModulesPlugin'](),
+            new webpackPlugins.WebpackChunkHashPlugin()
+        );
+    }
+
+    if (Mix.options.purifyCss) {
+        let PurifyCSSPlugin = require('purifycss-webpack');
+
+        // By default, we'll scan all Blade and Vue files in our project.
+        let paths = glob.sync(Mix.Paths.root('resources/views/**/*.blade.php')).concat(
+            Mix.entry().get().scripts().reduce((carry, js) => {
+                return carry.concat(glob.sync(js.entry.map(entry => entry.base) + '/**/*.vue'));
+            }, [])
+        );
+
+        plugins.push(new PurifyCSSPlugin(
+            Object.assign({ paths }, Mix.options.purifyCss, { minimize: Mix.inProduction })
+        ));
+    }
+
+    if (Mix.inProduction) {
+        plugins.push(
+            new webpack.DefinePlugin({
+                'process.env': {
+                    NODE_ENV: '"production"'
+                }
+            })
+        );
+
+        if (Mix.options.uglify) {
+            plugins.push(
+                new webpack.optimize.UglifyJsPlugin(Mix.options.uglify)
+            );
+        }
+    }
+
+    plugins.push(
+        new webpackPlugins.WebpackOnBuildPlugin(
+            stats => global.events.fire('build', stats)
         )
     );
-}
 
-if (Mix.options.notifications) {
-    plugins.push(
-        new webpackPlugins.WebpackNotifierPlugin({
-            title: 'Laravel Mix',
-            alwaysNotify: true,
-            contentImage: Mix.Paths.root('node_modules/laravel-mix/icons/laravel.png')
-        })
-    );
-}
+    if (! Mix.entry().hasScripts()) {
+        plugins.push(new webpackPlugins.MockEntryPlugin(Mix.output().path));
+    }
 
-if (Mix.copy) {
-    Mix.copy.forEach(copy => {
-        plugins.push(
-            new webpackPlugins.CopyWebpackPlugin([copy])
-        );
-    });
-}
+    config.plugins = plugins;
 
-if (Mix.entry().hasExtractions()) {
-    plugins.push(
-        new webpack.optimize.CommonsChunkPlugin({
-            names: Mix.entry().getExtractions(),
-            minChunks: Infinity
-        })
-    );
-}
 
-if (Mix.options.versioning) {
-    plugins.push(
-        new webpack[Mix.inProduction ? 'HashedModuleIdsPlugin': 'NamedModulesPlugin'](),
-        new webpackPlugins.WebpackChunkHashPlugin()
-    );
-}
 
-if (Mix.options.purifyCss) {
-    let PurifyCSSPlugin = require('purifycss-webpack');
+    /*
+     |--------------------------------------------------------------------------
+     | Mix Finalizing
+     |--------------------------------------------------------------------------
+     |
+     | Now that we've declared the entirety of our Webpack configuration, the
+     | final step is to scan for any custom configuration in the Mix file.
+     | If mix.webpackConfig() is called, we'll merge it in, and build!
+     |
+     */
 
-    // By default, we'll scan all Blade and Vue files in our project.
-    let paths = glob.sync(Mix.Paths.root('resources/views/**/*.blade.php')).concat(
-        Mix.entry().get().scripts().reduce((carry, js) => {
-            return carry.concat(glob.sync(js.entry.map(entry => entry.base) + '/**/*.vue'));
-        }, [])
-    );
-
-    plugins.push(new PurifyCSSPlugin(
-        Object.assign({ paths }, Mix.options.purifyCss, { minimize: Mix.inProduction })
-    ));
-}
-
-if (Mix.inProduction) {
-    plugins.push(
-        new webpack.DefinePlugin({
-            'process.env': {
-                NODE_ENV: '"production"'
-            }
-        })
-    );
-
-    if (Mix.options.uglify) {
-        plugins.push(
-            new webpack.optimize.UglifyJsPlugin(Mix.options.uglify)
+    if (Mix.webpackConfig) {
+        config = require('webpack-merge').smart(
+            config, Mix.webpackConfig
         );
     }
-}
 
-plugins.push(
-    new webpackPlugins.WebpackOnBuildPlugin(
-        stats => global.events.fire('build', stats)
-    )
-);
-
-if (! Mix.entry().hasScripts()) {
-    plugins.push(new webpackPlugins.MockEntryPlugin(Mix.output().path));
-}
-
-module.exports.plugins = plugins;
-
-
-
-/*
- |--------------------------------------------------------------------------
- | Mix Finalizing
- |--------------------------------------------------------------------------
- |
- | Now that we've declared the entirety of our Webpack configuration, the
- | final step is to scan for any custom configuration in the Mix file.
- | If mix.webpackConfig() is called, we'll merge it in, and build!
- |
- */
-
-if (Mix.webpackConfig) {
-    module.exports = require('webpack-merge').smart(
-        module.exports, Mix.webpackConfig
-    );
-}
+    return config;
+};

--- a/src/Api.js
+++ b/src/Api.js
@@ -375,6 +375,21 @@ class Api {
 
         return this;
     }
+
+    /**
+     * Add task to tasks collection.
+     *
+     * @param {string} taskName
+     * @param {(function()|Array)} callbackOrDependencies
+     * @returns {Api}
+     */
+    task(taskName, callbackOrDependencies) {
+        Verify.task(taskName, callbackOrDependencies);
+
+        global.tasks.addTask(taskName, callbackOrDependencies);
+
+        return this;
+    }
 }
 
 module.exports = Api;

--- a/src/Mix.js
+++ b/src/Mix.js
@@ -17,8 +17,10 @@ class Mix {
 
     /**
      * Initialize the user's webpack.mix.js configuration file.
+     *
+     * @param {string} tasks
      */
-    initialize() {
+    initialize({tasks}) {
         if (this.isUsingLaravel()) {
             this.publicPath = options.publicPath = 'public';
         }
@@ -27,6 +29,8 @@ class Mix {
 
         // This is where we load the user's webpack.mix.js config.
         File.exists(Paths.mix() + '.js') && require(Paths.mix());
+
+        typeof tasks === 'string' && global.tasks.initializeTasks(tasks.split(','));
 
         if (options.versioning) {
             this.versioning = new Versioning(this.version, this.manifest).watch();

--- a/src/Tasks.js
+++ b/src/Tasks.js
@@ -1,0 +1,66 @@
+class Tasks {
+
+    constructor() {
+        this.tasks = new Map();
+    }
+
+    /**
+     * Add task to the tasks list.
+     *
+     * @param {string} name
+     * @param {(function()|Array)} task
+     * @returns {Tasks}
+     */
+    addTask(name, task) {
+        this.tasks.set(name, task);
+
+        return this;
+    }
+
+    /**
+     * Run provided tasks.
+     *
+     * @param {Array} neededTasks
+     */
+    initializeTasks(neededTasks) {
+        this.resolveTasksCallbacks(neededTasks).forEach(task => task());
+    }
+
+    /**
+     * Determine unique callbacks for tasks.
+     *
+     * @param {Array} tasks
+     * @returns {Set}
+     */
+    resolveTasksCallbacks(tasks) {
+        let callbacks = new Set();
+
+        let resolver = (taskName, task) => {
+            task = typeof taskName === 'function' ? taskName : task;
+
+            if (this.tasks.has(taskName)) {
+                task = this.tasks.get(taskName);
+            }
+
+            if (Array.isArray(task)) {
+                if (task.includes(taskName)) {
+                    throw new Error(`Task "${taskName}" contain self referenced task`);
+                }
+
+                this.resolveTasksCallbacks(task).forEach(task => callbacks.add(task));
+            }
+
+            if (typeof task === 'function') {
+                callbacks.add(task);
+            }
+        };
+
+        if (tasks.includes('all')) {
+            this.tasks.forEach(resolver);
+        } else {
+            tasks.forEach(resolver);
+        }
+
+        return callbacks;
+    }
+}

--- a/src/Verify.js
+++ b/src/Verify.js
@@ -79,6 +79,24 @@ class Verify {
             }
         }
     }
+
+    /**
+     * Verify that the call the mix.task() is valid.
+     *
+     * @param {string} taskName
+     * @param {(function()|Array)} task
+     */
+    static task(taskName, task) {
+        assert(
+            typeof taskName === 'string',
+            'mix.task() is missing required parameter 1: {string} taskName'
+        );
+
+        assert(
+            typeof task === 'function' || Array.isArray(task),
+            'mix.task() is missing required parameter 2: ({function(mix)}|Array) task'
+        );
+    }
 }
 
 module.exports = Verify;

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ global.path = require('path');
 global.Paths = new (require('./Paths'));
 global.events = new (require('./Dispatcher'));
 global.File = require('./File');
+global.tasks = require('./Tasks');
 
 let mix = new (require('./Mix'));
 

--- a/test/concat.js
+++ b/test/concat.js
@@ -65,7 +65,7 @@ test('that it can combine files while applying versioning', t => {
     mix.combine([one.path(), two.path()], output.path())
        .version();
 
-    Mix.initialize();
+    Mix.initialize({});
 
     // We'll listen for the "combined" event, so that
     // we can fetch the generated file names.

--- a/test/verify.js
+++ b/test/verify.js
@@ -21,3 +21,10 @@ test('that it verifies mix.extract() params', t => {
     t.throws(() => Verify.extract('without-array'));
     t.notThrows(() => Verify.extract(['lib']));
 });
+
+test('that it verifies mix.task() params', t => {
+    t.throws(() => Verify.task());
+    t.throws(() => Verify.task('task'));
+    t.notThrows(() => Verify.task('task', (mix) => {}));
+    t.notThrows(() => Verify.task('task', ['another-task']))
+});


### PR DESCRIPTION
How to use:

```js
mix.task('login-page', () => {
    mix.js('resources/assets/js/pages/auth/login.js', 'public/assets/js/pages')
        .sass('resources/assets/sass/pages/auth/login.scss', 'public/assets/css/pages')
});

mix.task('register-page', () => {
    mix.js('resources/assets/js/pages/auth/register.js', 'public/assets/js/pages')
        .sass('resources/assets/sass/pages/auth/register.scss', 'public/assets/css/pages')
});

mix.extract(['vue']);
mix.sass('resources/assets/sass/main/app.scss', 'public/assets/css');

// Combined task. Running this task will cause in running all tasks specified in second argument.
mix.task('auth', ['login-page', 'register-page']);
```
To run specific tasks: `node run dev -- --env.tasks=login-page` or `node run dev -- --env.tasks=login-page,register-page`. Or you can use special task keyword "all" for run all defined tasks.

Unfortunately, i didn't find the more convenient way for providing tasks into script. In my opinion `--env.tasks =` looks some ugly. If somebody knows how the same can be achieved in another way, please say)