### PR TITLE
Remove wrong information about jQuery autoloading

### DIFF
--- a/docs/autoloading.md
+++ b/docs/autoloading.md
@@ -8,7 +8,7 @@ mix.autoload({
 
 webpack offers the necessary facilities to make a module available as a variable in every other module required by webpack. If you're working with a particular plugin or library that depends upon a global variable, such as jQuery, `mix.autoload()` may prove useful to you.
 
-> In fact, because jQuery is such a frequent example, Laravel Mix ships with jQuery autoloading out of the box. Should you need to disable this, you may pass an empty object to `mix.autoload({})`.
+> Before version 0.9, Laravel Mix shipped with jQuery autoloading out of the box. This isn't the case anymore!
 
 Consider the following example:
 

--- a/setup/webpack.config.js
+++ b/setup/webpack.config.js
@@ -393,8 +393,13 @@ if (Mix.inProduction) {
             }
         }),
 
-        new webpack.optimize.UglifyJsPlugin(Mix.options.uglify)
     );
+
+    if (Mix.options.uglify) {
+        plugins.push(
+            new webpack.optimize.UglifyJsPlugin(Mix.options.uglify)
+        );
+    }
 }
 
 plugins.push(


### PR DESCRIPTION
Remove the information that jQuery is still being autoloaded by Laravel Mix and added a short paragraph that the behaviour changed. Fix #615