### PR TITLE
Change Mix.output() method.

### DIFF
--- a/src/Mix.js
+++ b/src/Mix.js
@@ -61,7 +61,7 @@ class Mix {
             path: path.resolve(options.hmr ? '/' : options.publicPath),
             filename: filename,
             chunkFilename: chunkFilename.replace(/^\//, ''),
-            publicPath: options.hmr ? 'http://localhost:8080/' : ''
+            publicPath: options.hmr ? 'http://localhost:8080/' : options.resourceRoot
         };
     }
 


### PR DESCRIPTION
I think the mix.setResourceRoot() method should change the output.publicPath option value due to the method comments, but it DOES NOT. So I made a small change :smile: