### PR TITLE
Lets you import scss files from javascript and at the same time compile your sass with the sass() call

### DIFF
--- a/setup/webpack.config.js
+++ b/setup/webpack.config.js
@@ -130,15 +130,7 @@ let rules = [
 
     {
         test: /\.s[ac]ss$/,
-        exclude: (()=>{
-            if (Mix.preprocessors) {
-                let preprocessorsExcludes = [];
-                Mix.preprocessors.forEach(preprocessor => {
-                    preprocessorsExcludes.push(preprocessor.test());
-                });
-                return preprocessorsExcludes;
-            }
-        })(),
+        exclude: Mix.preprocessors.map(preprocessor => preprocessor.test()),
         loaders: ['style-loader', 'css-loader', 'sass-loader']
     },
 

--- a/setup/webpack.config.js
+++ b/setup/webpack.config.js
@@ -130,7 +130,15 @@ let rules = [
 
     {
         test: /\.s[ac]ss$/,
-        include: /node_modules/,
+        exclude: (()=>{
+            if (Mix.preprocessors) {
+                let preprocessorsExcludes = [];
+                Mix.preprocessors.forEach(preprocessor => {
+                    preprocessorsExcludes.push(preprocessor.test());
+                });
+                return preprocessorsExcludes;
+            }
+        })(),
         loaders: ['style-loader', 'css-loader', 'sass-loader']
     },
 


### PR DESCRIPTION
Let's allow you to import .scss files into javascript files when you use mix.js() or mix.react() together with mix.sass().

See issue #525