### PR TITLE
Removed SVG from webpack test

### DIFF
--- a/setup/webpack.config.js
+++ b/setup/webpack.config.js
@@ -164,7 +164,7 @@ let rules = [
     },
 
     {
-        test: /\.(woff2?|ttf|eot|svg|otf)$/,
+        test: /\.(woff2?|ttf|eot|otf)$/,
         loader: 'file-loader',
         options: {
             name: path => {


### PR DESCRIPTION
I feel that putting SVG files in a fonts directory by default is an assumption that should not be made as a default setting. 

Such a file extension does not define a font and should therefore be implemented by a user themselves.