### PR TITLE
Cleared up index dependencies

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,15 +1,24 @@
-global.options = require('./Options');
-global.entry = require('./Entry');
-global.path = require('path');
-global.Paths = new (require('./Paths'));
-global.events = new (require('./Dispatcher'));
-global.File = require('./File');
+let Mix = require('./Mix');
+let Paths = require('./Paths');
+let Dispatcher = require('./Dispatcher');
+let Api = require('./Api');
+let Options = require('./Options');
+let Entry = require('./Entry');
+let path = require('path');
+let File = require('./File');
 
-let mix = new (require('./Mix'));
+global.options = Options;
+global.entry = Entry;
+global.path = path;
+global.File = File;
+global.Paths = new Paths();
+global.events = new Dispatcher();
+
+let mix = new Mix();
 
 // The default export for this module will in fact
 // be the fluent API for your webpack.mix.js file.
-module.exports = api = new (require('./Api'))(mix);
+module.exports = api = new Api(mix);
 module.exports.mix = api; // Deprecated.
 
 // However, you can access the Mix instance like this:


### PR DESCRIPTION
Although instantiating the classes directly with the require might save some line space it does not provide any overview at all.

This is especially worrying when you come across a class like `Dispatcher` and try to look for `new Dispatcher()` within the project scope. You won't find anything since the syntax is: 

```JS
new (require('./Dispatcher'));
```

Instead of:

```JS
new Dispatcher();
```

Ofcourse you can hunt the code for the `require` but it might be in multiple places for some classes.
Preferably the plugins might be split off from this file later on to clean it up a bit further.
