### PR TITLE
finalizeWebpackConfig

### DIFF
--- a/setup/webpack.config.js
+++ b/setup/webpack.config.js
@@ -417,12 +417,12 @@ module.exports.plugins = plugins;
 
 /*
  |--------------------------------------------------------------------------
- | Mix Finalizing
+ | Mix Finalizing - Part 1
  |--------------------------------------------------------------------------
  |
- | Now that we've declared the entirety of our Webpack configuration, the
- | final step is to scan for any custom configuration in the Mix file.
- | If mix.webpackConfig() is called, we'll merge it in, and build!
+ | Now that we've declared the entirety of our Webpack configuration, scan
+ | for any custom configuration in the Mix file.
+ | If mix.webpackConfig() is called, we'll merge it in.
  |
  */
 
@@ -430,4 +430,18 @@ if (Mix.webpackConfig) {
     module.exports = require('webpack-merge').smart(
         module.exports, Mix.webpackConfig
     );
+}
+
+/*
+ |--------------------------------------------------------------------------
+ | Mix Finalizing - Part 2
+ |--------------------------------------------------------------------------
+ |
+ | Lastly and if provided via mix.finalizeWebpackConfig, invoke the
+ | finalizer callback to modify the final config object and build!
+ |
+ */
+
+if (Mix.webpackConfigFinalizer) {
+    Mix.webpackConfigFinalizer(module.exports);
 }

--- a/setup/webpack.mix.js
+++ b/setup/webpack.mix.js
@@ -35,6 +35,7 @@ mix.js('src/app.js', 'dist/')
 // mix.setResourceRoot('prefix/for/resource/locators');
 // mix.autoload({}); <-- Will be passed to Webpack's ProvidePlugin.
 // mix.webpackConfig({}); <-- Override webpack.config.js, without editing the file directly.
+// mix.finalizeWebpackConfig(callback); <-- Provide a callback that modifies the final config object.
 // mix.then(function () {}) <-- Will be triggered each time Webpack finishes building.
 // mix.options({
 //   extractVueStyles: false, // Extract .vue component styling to file, rather than inline.

--- a/src/Api.js
+++ b/src/Api.js
@@ -342,6 +342,17 @@ class Api {
         return this;
     }
 
+    /**
+     * Provide a finalizer callback that receives the full config object
+     * for an opportunity to do custom modifications to it.
+     * 
+     * @param {function} callback
+     */
+    finalizeWebpackConfig(callback) {
+        this.Mix.webpackConfigFinalizer = callback;
+
+        return this;
+    }
 
     /**
      * Set Mix-specific options.


### PR DESCRIPTION
Fixes https://github.com/JeffreyWay/laravel-mix/issues/688.

This allows me to do the following in my mix config file:
```js
mix
  .finalizeWebpackConfig(config => {
    const rule = config.module.rules.find(rule => rule.loader === 'vue-loader')
    rule.options.postLoaders = { html: 'babel-loader' }
  })
```