### PR TITLE
Add LESS support when using vueExtractTextPlugin

### DIFF
--- a/setup/webpack.config.js
+++ b/setup/webpack.config.js
@@ -98,6 +98,10 @@ let rules = [
                     use: 'css-loader!sass-loader?indentedSyntax',
                     fallback: 'vue-style-loader'
                 }),
+                less: vueExtractTextPlugin.extract({
+                    use: 'css-loader!less-loader',
+                    fallback: 'vue-style-loader'
+                }),
                 stylus: vueExtractTextPlugin.extract({
                     use: 'css-loader!stylus-loader?paths[]=node_modules',
                     fallback: 'vue-style-loader'
@@ -110,6 +114,7 @@ let rules = [
                 js: 'babel-loader' + Mix.babelConfig(),
                 scss: 'vue-style-loader!css-loader!sass-loader',
                 sass: 'vue-style-loader!css-loader!sass-loader?indentedSyntax',
+                less: 'vue-style-loader!css-loader!less-loader',
                 stylus: 'vue-style-loader!css-loader!stylus-loader?paths[]=node_modules'
             },
 


### PR DESCRIPTION
Using the following with LESS inside Vue single file components was resulting in no extraction of the app.css file via vueExtractTextPlugin (see last line below). Added a LESS specific loader to the webpack.config.js file which should fix this.

```javascript
const { mix } = require('laravel-mix');
mix.less('resources/assets/less/site.less', 'public/css/site.css');
mix.js('resources/assets/js/site.js', 'public/js');
mix.js('resources/assets/js/app.js', 'public/js')
  .options({ extractVueStyles: 'public/css/app.css' });
```
