### PR TITLE
Allow sourcemaps to be generated for production

### DIFF
--- a/src/Api.js
+++ b/src/Api.js
@@ -274,9 +274,11 @@ class Api {
 
     /**
      * Enable sourcemap support.
+     *
+     * @param {boolean} always
      */
-    sourceMaps() {
-        global.options.sourcemaps = (this.Mix.inProduction ? false : '#inline-source-map');
+    sourceMaps(always = false) {
+        global.options.sourcemaps = ( this.Mix.inProduction ? ( always ? '#source-map' : false ) : '#inline-source-map' );
 
         return this;
     };


### PR DESCRIPTION
Adding always parameter to generate separate file sourcemaps when in production mode.

Coming from elixir which had the `elixir.config.sourcemaps = true;` option to always generate sourcemaps even in production was useful for us, since we use Sentry for providing insights into errors in JS Code. :)