### PR TITLE
Allow different types of source mapping, by default `#inline-source-map`

### DIFF
--- a/src/Api.js
+++ b/src/Api.js
@@ -266,9 +266,11 @@ class Api {
 
     /**
      * Enable sourcemap support.
+     *
+     * @param {string} type
      */
-    sourceMaps() {
-        global.options.sourcemaps = (this.Mix.inProduction ? false : '#inline-source-map');
+    sourceMaps(type = '#inline-source-map') {
+        global.options.sourcemaps = (this.Mix.inProduction ? false : type);
 
         return this;
     };


### PR DESCRIPTION
This allows for multiple ways to use sourceMaps without needing to add custom webpack options.
https://webpack.github.io/docs/configuration.html#devtool

The sourceMapFilename is by default [filename].map if the source map is a separate file using `#sourcemap`

