### PR TITLE
Adds support for cleanCSS options to method minify

### DIFF
--- a/src/File.js
+++ b/src/File.js
@@ -48,7 +48,7 @@ class File {
 
         if (this.fileType === '.css') {
             this.write(
-                new UglifyCss().minify(this.read()).styles
+                new UglifyCss(options.cleanCss).minify(this.read()).styles
             );
         }
     }

--- a/src/Options.js
+++ b/src/Options.js
@@ -153,6 +153,16 @@ module.exports = {
 
 
     /**
+     * CleanCss-specific settings for Webpack.
+     *
+     * See: https://github.com/jakubpawlowicz/clean-css#constructor-options
+     *
+     * @type {Object}
+     */
+    cleanCss: {
+    },
+
+    /**
      * Merge the given options with the current defaults.
      *
      * @param {object} options

--- a/test/file.js
+++ b/test/file.js
@@ -2,6 +2,7 @@ import test from 'ava';
 import path from 'path';
 import File from '../src/File';
 import sinon from 'sinon';
+import options from '../src/Options';
 
 global.File = File;
 global.path = path;
@@ -45,6 +46,23 @@ test('that it minifies JS and CSS files properly.', t => {
     dummyCssFile.delete();
 });
 
+test('that it minifies CSS files properly with specific options', t => {
+    let dummyCssFilePath = path.resolve(__dirname, 'dummy.css');
+
+    let cssCodeToMinify = new File(path.resolve(__dirname, 'fixtures/minifyme-options.css')).read();
+    let cssCodeMinified = new File(path.resolve(__dirname, 'fixtures/minifyme-options.min.css')).read();
+
+    options.cleanCss = {
+        level: 2
+    };
+
+    let dummyCssFile = new File(dummyCssFilePath).write(cssCodeToMinify);
+
+    dummyCssFile.minify();
+    t.is(dummyCssFile.read(), cssCodeMinified);
+
+    dummyCssFile.delete();
+});
 
 test('that it can rename a file', t => {
     let before = path.resolve(__dirname, 'before.js');

--- a/test/fixtures/minifyme-options.css
+++ b/test/fixtures/minifyme-options.css
@@ -1,0 +1,8 @@
+.minify {
+  /* this rule will be discard */
+  color: red;
+}
+
+.minify {
+  color: green;
+}

--- a/test/fixtures/minifyme-options.min.css
+++ b/test/fixtures/minifyme-options.min.css
@@ -1,0 +1,1 @@
+.minify{color:green}


### PR DESCRIPTION
I've added support to allow to specify cleanCss options when minifying CSS. 
I also added one simple test just to check if options are passed correctly to the CleanCss constructor. 
This pull request addresses issue #735 