### PR TITLE
Fix for Issue 200 failing to parse scss on Windows

### DIFF
--- a/src/Preprocessors/Preprocessor.js
+++ b/src/Preprocessors/Preprocessor.js
@@ -58,7 +58,7 @@ class Preprocessor {
      * Get the regular expression test for the Extract plugin.
      */
     test() {
-        return new RegExp(this.src.path.replace(/\\/g, '\\\\') + '$');
+        return new RegExp(this.src.file.replace(/\\/g, '\\\\') + '$');
     }
 
 


### PR DESCRIPTION
This fix comes from https://github.com/JeffreyWay/laravel-mix/issues/200 in a post by Datazource. The thread contains many peoples issues and solutions. This one works for me and was wondering if this affected anyone else.

Change :
    test() {
        return new RegExp(this.src.path.replace(/\\/g, '\\\\') + '$');
    }
To :
    test() {
        return new RegExp(this.src.file.replace(/\\/g, '\\\\') + '$');
    }