### PR TITLE
fixed wording for clarity

### DIFF
--- a/docs/copying-files.md
+++ b/docs/copying-files.md
@@ -13,5 +13,5 @@ From time to time, you'll want to copy one or more files, as part of your build 
 mix.copy('node_modules/vendor/acme.txt', 'public/js/acme.txt');
 ```
 
-Upon compilation, the "acme" directory will be moved to `public/js/acme.txt`, accordingly. A common use case for this is when you wish to move a set of fonts, installed through NPM, to your public directory.
+Upon compilation, the "acme" file will be copied to `public/js/acme.txt`, accordingly. A common use case for this is when you wish to move a set of fonts, installed through NPM, to your public directory.
 


### PR DESCRIPTION
### Issue:
In the copying-file example, the text mentions:
```the "acme" directory will be moved```
Since the example is showing how to copy a file, it seems more appropriate to say:
```the "acme" file will be copied```

### Currently in copying-files.md:
```mix.copy('node_modules/vendor/acme.txt', 'public/js/acme.txt');```

> Upon compilation, the "acme" directory will be moved to public/js/acme.txt, accordingly. A common use case for this is when you wish to move a set of fonts, installed through NPM, to your public directory.

### After changes:
```mix.copy('node_modules/vendor/acme.txt', 'public/js/acme.txt');```

> Upon compilation, the "acme" file will be copied to public/js/acme.txt, accordingly. A common use case for this is when you wish to move a set of fonts, installed through NPM, to your public directory.
