### PR TITLE
Add reference to 'copy-webpack-plugin' in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "chokidar": "^1.6.1",
     "clean-css": "^4.0.7",
     "concatenate": "0.0.2",
+    "copy-webpack-plugin": "^4.0.1",
     "cross-env": "^3.1.3",
     "css-loader": "^0.14.5",
     "dotenv": "^4.0.0",


### PR DESCRIPTION
When running `npm run test` in the repo it barks about missing `copy-webpack-plugin`. This adds it as a dep in package.json.