### PR TITLE
Disable ExtractTextPlugin for preprocessors when Hot Module Reloading

### DIFF
--- a/src/Preprocessors/Preprocessor.js
+++ b/src/Preprocessors/Preprocessor.js
@@ -30,7 +30,10 @@ class Preprocessor {
      */
     getExtractPlugin() {
         if (! this.extractPlugin) {
-            this.extractPlugin = new ExtractTextPlugin(this.outputPath());
+            this.extractPlugin = new ExtractTextPlugin({
+                filename: this.outputPath(),
+                disable: global.options.hmr
+            });
         }
 
         return this.extractPlugin;


### PR DESCRIPTION
This allows webpack dev server to appropriately inject css updates. Currently css refreshing outside of your js bundle does not work properly with Hot Module Reloading.