### PR TITLE
Strip control codes from node-sass failure output 

### DIFF
--- a/src/Preprocessors/StandaloneSass.js
+++ b/src/Preprocessors/StandaloneSass.js
@@ -144,6 +144,7 @@ class StandaloneSass {
      * @param {string} output
      */
     onFail(output) {
+        output = output.replace(/[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g, '');
         console.log("\n");
         console.log('Sass Compilation Failed!');
         console.log();


### PR DESCRIPTION
When standaloneSass function is used in watch mode (e.g. npm run watch), node-sass can produce JSON with control characters.  This throws an error in the onFail method of StandaloneSass.js as the JSON.parse fails and kills the process.

The issue does not happen when running in my regular iTerm, however in PHPStorm, using the Tools -> Run Gulp/Grunt/npm task (which is a really handy way to start up this process during dev :)) any time sass compilation fails, I need to restart the watch.

This single line fix replaces out (most) known ANSI control characters before attempting to parse the JSON.