### PR TITLE
add imgLoaderOptions

### DIFF
--- a/setup/webpack.config.js
+++ b/setup/webpack.config.js
@@ -179,7 +179,10 @@ let rules = [
                     publicPath: Mix.options.resourceRoot
                 }
             },
-            'img-loader'
+            {
+                loader: 'img-loader',
+                options: Mix.options.imgLoaderOptions
+            }
         ]
     },
 

--- a/src/Options.js
+++ b/src/Options.js
@@ -117,6 +117,18 @@ module.exports = {
         }
     },
 
+    /**
+    * img-loader settings for Webpack.
+    * See: https://github.com/thetalecrafter/img-loader#options
+    * @type {Object}
+    */
+    imgLoaderOptions: {
+        enabled: false,
+        gifsicle: false,
+        mozjpeg: false,
+        optipng: false,
+        svgo: false,
+    },
 
     /**
      * PostCSS plugins to be applied to compiled CSS.


### PR DESCRIPTION
we can disable the `imagemin` action to reduce build time. To enable it:

```
mix.options({
    imgLoaderOptions: {
        enabled: true,
        gifsicle: {},
        mozjpeg: {},
        optipng: {},
        svgo: {},
    }
})
```

https://github.com/JeffreyWay/laravel-mix/issues/426#issuecomment-299649992