### PR TITLE
Set the sourcemap option for the sass plugin according to the current configuration

### DIFF
--- a/src/Preprocessors/Sass.js
+++ b/src/Preprocessors/Sass.js
@@ -6,7 +6,7 @@ class Sass extends Preprocessor {
      */
     loaders(sourceMaps) {
         let loaders = [
-            { loader: 'sass-loader', options: this.sassPluginOptions() }
+            { loader: 'sass-loader', options: this.sassPluginOptions(sourceMaps) }
         ];
 
         if (global.options.processCssUrls) {
@@ -22,11 +22,11 @@ class Sass extends Preprocessor {
     /**
      * Fetch the Node-Sass-specififc plugin options.
      */
-    sassPluginOptions() {
+    sassPluginOptions(sourceMaps) {
         return Object.assign({
             precision: 8,
             outputStyle: 'expanded'
-        }, this.pluginOptions, { sourceMap: true })
+        }, this.pluginOptions, { sourceMap: sourceMaps })
     }
 }
 


### PR DESCRIPTION
The sourcemap option shouldn't be always true for the sass plugin, instead we can set it based on the mix configuration.