### PR TITLE
Add support TypeScript

### DIFF
--- a/setup/webpack.config.js
+++ b/setup/webpack.config.js
@@ -215,6 +215,18 @@ let rules = [
     }
 ];
 
+let extensions = ['*', '.js', '.jsx', '.vue'];
+
+if (Mix.ts) {
+    rules.push({
+        test: /\.tsx?$/,
+        loader: 'ts-loader',
+        exclude: /node_modules/,
+    });
+
+    extensions.push('.ts', '.tsx')
+}
+
 let sassRule = {
     test: /\.s[ac]ss$/,
     loaders: ['style-loader', 'css-loader', 'sass-loader']
@@ -250,7 +262,7 @@ module.exports.module = { rules };
  */
 
 module.exports.resolve = {
-    extensions: ['*', '.js', '.jsx', '.vue'],
+    extensions,
 
     alias: {
         'vue$': 'vue/dist/vue.common.js'

--- a/src/Api.js
+++ b/src/Api.js
@@ -39,6 +39,21 @@ class Api {
         return this;
     };
 
+    /**
+     * Declare support for the TypeScript.
+     */
+    ts(entry, output) {
+        this.Mix.ts = true;
+
+        Verify.dependency(
+            'ts-loader',
+            'npm install ts-loader typescript --save-dev'
+        );
+
+        this.js(entry, output);
+
+        return this;
+    };
 
     /**
      * Register vendor libs that should be extracted.


### PR DESCRIPTION
# Add support TypyScript
Install TypeScript before using:
```shell
$ npm install ts-loader typescript --save-dev
```
Usage:
```js
// webpack.mix.js
let mix = require('laravel-mix');
mix.ts('src/hello-word.ts', 'dist/');
```