### PR TITLE
Remove cross-env from scripts section

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,10 +4,10 @@
   "description": "Laravel Mix is an elegant wrapper around Webpack for the 80% use case.",
   "main": "src/index.js",
   "scripts": {
-    "webpack": "cross-env NODE_ENV=development webpack --progress --hide-modules",
-    "dev": "cross-env NODE_ENV=development webpack --watch --progress --hide-modules",
-    "hmr": "cross-env NODE_ENV=development webpack-dev-server --inline --hot",
-    "production": "cross-env NODE_ENV=production webpack --progress --hide-modules",
+    "webpack": "NODE_ENV=development webpack --progress --hide-modules",
+    "dev": "NODE_ENV=development webpack --watch --progress --hide-modules",
+    "hmr": "NODE_ENV=development webpack-dev-server --inline --hot",
+    "production": "NODE_ENV=production webpack --progress --hide-modules",
     "test": "sudo nyc ava --verbose",
     "posttest": "nyc report --reporter=html"
   },


### PR DESCRIPTION
cross-env was removed here: https://github.com/JeffreyWay/laravel-mix/commit/cbe6418bcc0fd6d1fd3a26530107fc134d04fc64
but still used in the scripts section