### PR TITLE
#824 Added ability to disable success notifications

### DIFF
--- a/src/Api.js
+++ b/src/Api.js
@@ -382,7 +382,15 @@ class Api {
         Config.notifications = false;
 
         return this;
-    }
+    };
+
+    /**
+     * Disable success notifications.
+     */
+    disableSuccessNotifications() {
+        Config.notificationsOnSuccess = false;
+        return this;
+    };
 
 
     /**

--- a/src/builder/webpack-plugins.js
+++ b/src/builder/webpack-plugins.js
@@ -54,7 +54,7 @@ module.exports = function () {
         plugins.push(
             new WebpackNotifierPlugin({
                 title: 'Laravel Mix',
-                alwaysNotify: true,
+                alwaysNotify: Mix.isUsing('notificationsOnSuccess'),
                 contentImage: Mix.paths.root('node_modules/laravel-mix/icons/laravel.png')
             })
         );

--- a/src/config.js
+++ b/src/config.js
@@ -121,11 +121,19 @@ module.exports = function () {
 
 
         /**
-         * Determine if notifications should be displayed for each build.
+         * Determine if error notifications should be displayed for each build.
          *
          * @type {Boolean}
          */
         notifications: true,
+
+
+        /**
+         * Determine if we should always show success notifications.
+         *
+         * @type {Boolean}
+         */
+        notificationsOnSuccess: true,
 
 
         /**


### PR DESCRIPTION
Added ability to disable success notifications and only show errors. 
Will still show a single success notification if the previous build failed with an error, to indicate its clean now.

Fixes #824. The code was more or less built into the plugin we are using, so just had to wrap the API around it. You could possibly rename the config value if you want, but other than that I think we are clear. 