### PR TITLE
Add link to config in package.json for v1.0+

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -59,9 +59,9 @@ As a tip, consider adding the following NPM scripts to your `package.json` file,
 
 ```js
   "scripts": {
-    "dev": "NODE_ENV=development webpack --progress --hide-modules",
-    "watch": "NODE_ENV=development webpack --watch --progress --hide-modules",
-    "hot": "NODE_ENV=development webpack-dev-server --inline --hot",
-    "production": "NODE_ENV=production webpack --progress --hide-modules"
+    "dev": "NODE_ENV=development webpack --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js",
+    "watch": "NODE_ENV=development webpack --watch --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js",
+    "hot": "NODE_ENV=development webpack-dev-server --inline --hot --config=node_modules/laravel-mix/setup/webpack.config.js",
+    "production": "NODE_ENV=production webpack --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js"
   }
 ```


### PR DESCRIPTION
The reason for this is because `webpack.config.js` is no longer in the root directory by default.

Signed-off-by: Ru Chern Chong <me@ruchern.com>