### PR TITLE
add option to prevent the manifest file from being created

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -2,6 +2,7 @@
 
 ```js
 mix.options({
+  createManifest: true,
   extractVueStyles: false,
   processCssUrls: true,
   uglify: {},
@@ -14,6 +15,7 @@ mix.options({
 
 A handful of Mix options and overrides are available, should you require them. Please take note of the options above, as well as their default values. Here's a quick overview:
 
+- **createManifest:** Set this to false, if you don't want the manifest file to be created.
 - **extractVueStyles:** Extract `.vue` component styling (CSS within `<style>` tags) to a dedicated file, rather than inlining it into the HTML.
 - **processCssUrls:** Process/optimize relative stylesheet url()'s. By default, Webpack will automatically update these URLs, when relevant. If, however, your folder structure is already organized the way you want it, set this option to `false` to disable processing.
 - **uglify:** Use this option to merge any [custom Uglify options](https://webpack.github.io/docs/list-of-plugins.html#uglifyjsplugin) that your project requires.

--- a/setup/webpack.mix.js
+++ b/setup/webpack.mix.js
@@ -38,6 +38,7 @@ mix.js('src/app.js', 'dist/')
 // mix.webpackConfig({}); <-- Override webpack.config.js, without editing the file directly.
 // mix.then(function () {}) <-- Will be triggered each time Webpack finishes building.
 // mix.options({
+//   createManifest: true, // Create the manifest file.
 //   extractVueStyles: false, // Extract .vue component styling to file, rather than inline.
 //   processCssUrls: true, // Process/optimize relative stylesheet url()'s. Set to false, if you don't want them touched.
 //   purifyCss: false, // Remove unused CSS selectors.

--- a/src/Manifest.js
+++ b/src/Manifest.js
@@ -75,10 +75,12 @@ class Manifest {
 
 
     /**
-     * Refresh the mix-manifest.js file.
+     * Refresh the mix-manifest.json file.
      */
     refresh() {
+        if (Config.createManifest) {
         File.find(this.path()).write(this.manifest);
+        }
     }
 
 

--- a/src/Manifest.js
+++ b/src/Manifest.js
@@ -79,7 +79,7 @@ class Manifest {
      */
     refresh() {
         if (Config.createManifest) {
-        File.find(this.path()).write(this.manifest);
+            File.find(this.path()).write(this.manifest);
         }
     }
 

--- a/src/config.js
+++ b/src/config.js
@@ -213,6 +213,14 @@ module.exports = function () {
         },
 
         /**
+         * Determine if the manifest file should be created for the build.
+         *
+         * @type {Boolean}
+         */
+        createManifest: true,
+
+
+        /**
          * Determine if CSS url()s should be processed by Webpack.
          *
          * @type {Boolean}

--- a/test/manifest.js
+++ b/test/manifest.js
@@ -2,6 +2,7 @@ import test from 'ava';
 import mockFs from 'mock-fs';
 import mix from '../src/index';
 import Manifest from '../src/Manifest';
+import fs from 'fs-extra';
 
 test.beforeEach(() => Mix.manifest = new Manifest());
 
@@ -62,4 +63,24 @@ test('it can be refreshed', t => {
     t.deepEqual({ '/js/app.js': '/js/app.js' }, Mix.manifest.read());
 
     mockFs.restore();
+});
+
+
+test('it can refresh without creating the manifest file', t => {
+    fs.ensureDirSync('test/fixtures/fake-app/manifest');
+
+    mix.setPublicPath('test/fixtures/fake-app/manifest');
+
+    Config.createManifest = false;
+
+    // The manifest file should not exist.
+    t.false(File.exists('test/fixtures/fake-app/manifest/mix-manifest.json'));
+
+    // And after we refresh it...
+    Mix.manifest.refresh();
+
+    // The manifest file still does not exist.
+    t.false(File.exists('test/fixtures/fake-app/manifest/mix-manifest.json'));
+
+    fs.removeSync('test/fixtures/fake-app/manifest');
 });


### PR DESCRIPTION
My Instructor gave me the task to contribute to Open-Source projects.

While we where working on a project where we had no use for the manifest file, he thought it would be a nice addition to have the option to be able to prevent it from being created at all.

So i worked out this solution that prevents the refresh method from creating the mix-manifest.json if the option is set.

I hope i can contribute to awesome projects like this one in the future.

Best regards
Thorben