### PR TITLE
Use Vue.js ES Module build instead of commonjs

### DIFF
--- a/src/builder/WebpackConfig.js
+++ b/src/builder/WebpackConfig.js
@@ -111,7 +111,7 @@ class WebpackConfig {
             extensions,
 
             alias: {
-                'vue$': 'vue/dist/vue.common.js'
+                'vue$': 'vue/dist/vue.esm.js'
             }
         };
 


### PR DESCRIPTION
Personally, I think the ES-Module for Vue.js should be the recommended way.