### PR TITLE
fix:File.relativePath() when pointing outside of pwd(root) folder

### DIFF
--- a/src/File.js
+++ b/src/File.js
@@ -91,7 +91,7 @@ class File {
      * Get the relative path to the file, from the project root.
      */
     relativePath() {
-        return this.path().replace(Mix.paths.root() + path.sep, '');
+        return path.relative(Mix.paths.root(), this.path());
     }
 
 

--- a/test/file.js
+++ b/test/file.js
@@ -64,10 +64,14 @@ test('it knows the path to the file', t => {
 });
 
 
-test('it knows the relative to the file', t => {
+test('it knows the relative path to the file', t => {
     let file = new File('path/to/file.js');
 
-    t.is('path/to/file.js', file.relativePath());
+    let newFile = new File('../path/to/file.js');
+
+    t.true(['path/to/file.js', 'path\\to\\file.js'].includes(file.relativePath())); 
+
+    t.true(['../path/to/file.js', '..\\path\\to\\file.js'].includes(newFile.relativePath())); 
 });
 
 


### PR DESCRIPTION
Currently, when a given `File` is constructed with a relative `filePath` that point outside of the application root directory. For example :

```php
let file = new File('../path/to/file.js');
```
The path returned by `file.relativePath()` will be incorrect.

This PR fix that behavior, so that it always returns the correct path to `file.js` relative to the application root directory.