### PR TITLE
Serve static files from webpackDevServer

### DIFF
--- a/src/builder/webpack-default.js
+++ b/src/builder/webpack-default.js
@@ -35,6 +35,7 @@ module.exports = function () {
             headers: {
                 "Access-Control-Allow-Origin": "*"
             },
+            contentBase: path.resolve(Config.publicPath),
             historyApiFallback: true,
             noInfo: true,
             compress: true,


### PR DESCRIPTION
Adding the `contentBase` to the devServer config does fix hot reloading when using non-webpack combine & copy tasks together with hot reloading.

E.g. when using `combine()` and Laravel`s PHP `mix()` helper

This should resolve #344

Note: A side effect is, that possible PHP- and other files in the public directory are served by the dev server as well (in plain text).