### PR TITLE
Fix file watcher for custom tasks

### DIFF
--- a/src/Mix.js
+++ b/src/Mix.js
@@ -42,6 +42,14 @@ class Mix {
 
 
     /**
+     * Determine if polling is used for file watching
+     */
+    isPolling() {
+        return this.isWatching() && process.argv.includes('--watch-poll');
+    }
+
+
+    /**
      * Determine if Mix sees a particular tool or framework.
      *
      * @param {string} tool

--- a/src/plugins/CustomTasksPlugin.js
+++ b/src/plugins/CustomTasksPlugin.js
@@ -17,7 +17,7 @@ class CustomTasksPlugin {
             }
 
             if (Mix.isWatching()) {
-                Mix.tasks.forEach(task => task.watch());
+                Mix.tasks.forEach(task => task.watch(Mix.isPolling()));
             }
 
             Mix.manifest.refresh();

--- a/src/tasks/Task.js
+++ b/src/tasks/Task.js
@@ -21,7 +21,7 @@ class Task {
     watch(usePolling = false) {
         if (this.isBeingWatched) return;
 
-        const files = this.files.get()
+        const files = this.files.get();
         const watcher = chokidar.watch(files, { usePolling, persistent: true})
             .on('change', this.onChange.bind(this));
 
@@ -32,7 +32,7 @@ class Task {
                     watcher.unwatch(files);
                     watcher.add(files);
                 }
-            })
+            });
         }
 
         this.isBeingWatched = true;

--- a/src/tasks/Task.js
+++ b/src/tasks/Task.js
@@ -15,11 +15,14 @@ class Task {
 
     /**
      * Watch all relevant files for changes.
+     * 
+     * @param {boolean} usePolling
      */
-    watch() {
+    watch(usePolling = false) {
         if (this.isBeingWatched) return;
 
-        chokidar.watch(this.files.get(), { persistent: true })
+        const files = this.files.get()
+        const watcher = chokidar.watch(files, { usePolling, persistent: true})
             .on('change', this.onChange.bind(this));
 
         this.isBeingWatched = true;

--- a/src/tasks/Task.js
+++ b/src/tasks/Task.js
@@ -25,6 +25,16 @@ class Task {
         const watcher = chokidar.watch(files, { usePolling, persistent: true})
             .on('change', this.onChange.bind(this));
 
+        // workaround for issue with atomic writes (See https://github.com/paulmillr/chokidar/issues/591)
+        if (!usePolling) {
+            watcher.on('raw', (event, path, {watchedPath}) => {
+                if (event === 'rename') {
+                    watcher.unwatch(files);
+                    watcher.add(files);
+                }
+            })
+        }
+
         this.isBeingWatched = true;
     }
 }


### PR DESCRIPTION
This PR does two things:

- sets `usePolling` option for `chokidar` if mix/webpack has been called with `--watch-poll`. This ensures that polling is also used for custom tasks
- adds workaround for issue with atomic/safe writes + watch mode (See https://github.com/paulmillr/chokidar/issues/591)

This should fix #837