### PR TITLE
WIP: Source Maps when using combine()

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "license": "MIT",
   "dependencies": {
     "autoprefixer": "^7.1.1",
+    "babel-concat": "git+https://github.com/luigi-rosso/babel-concat.git",
     "babel-core": "^6.24.1",
     "babel-loader": "^7.1.1",
     "babel-preset-env": "^1.5.1",

--- a/src/Api.js
+++ b/src/Api.js
@@ -174,13 +174,14 @@ class Api {
      * @param {string|Array} src
      * @param {string}       output
      * @param {Boolean}      babel
+     * @param {Boolean}      skipSourceMaps
      */
-    combine(src, output, babel = false) {
+    combine(src, output, babel = false, skipSourceMaps = false) {
         output = new File(output || '');
 
         Verify.combine(src, output);
 
-        let task = new ConcatFilesTask({ src, output, babel });
+        let task = new ConcatFilesTask({ src, output, babel, skipSourceMaps });
 
         Mix.addTask(task);
 
@@ -193,9 +194,10 @@ class Api {
      *
      * @param {string|Array} src
      * @param {string}       output
+     * @param {Boolean}      skipSourceMaps
      */
-    scripts(src, output) {
-        return this.combine(src, output);
+    scripts(src, output, skipSourceMaps) {
+        return this.combine(src, output, skipSourceMaps);
     };
 
 
@@ -204,9 +206,10 @@ class Api {
      *
      * @param {string|Array} src
      * @param {string}       output
+     * @param {Boolean}      skipSourceMaps
      */
-    babel(src, output) {
-        return this.combine(src, output, true);
+    babel(src, output, skipSourceMaps) {
+        return this.combine(src, output, true, skipSourceMaps);
 
         return this;
     };

--- a/src/FileCollection.js
+++ b/src/FileCollection.js
@@ -1,4 +1,5 @@
 let concatenate = require('concatenate');
+let babelConcat = require("babel-concat")
 let babel = require('babel-core');
 let glob = require('glob');
 
@@ -28,15 +29,40 @@ class FileCollection {
      * @param {object} wantsBabel
      */
     merge(output, wantsBabel = false) {
-        let contents = concatenate.sync(
-            this.files, output.makeDirectories().path()
-        );
+        let filePath = output.makeDirectories().path();
 
-        if (this.shouldCompileWithBabel(wantsBabel, output)) {
-            output.write(this.babelify(contents));
+        let mapPath = output.makeDirectories().path() + '.map';
+        let mapOutput = new File(mapPath);
+
+        // merge js files with babel-concat
+        if (output.extension() === '.js') {
+          let sourceMaps = false;
+          if (Config.sourcemaps) {
+            /**
+             * in development: generate both inline & .map
+             * in production: generate only .map
+             */
+            sourceMaps = Mix.inProduction() ? true : 'both'
+          }
+
+          const result = babelConcat.transformFileSync(this.files, {
+            babelrc: false,
+            sourceMaps: sourceMaps,
+            sourceType: 'script',
+          });
+
+          output.write(result.code)
+          mapOutput.write(result.map)
+
+          if (this.shouldCompileWithBabel(wantsBabel, output)) {
+              output.write(this.babelify(result.code));
+          }
+
+          return [new File(filePath), new File(mapPath)];
+        } else {
+            concatenate.sync(this.files, filePath);
+            return [new File(filePath)];
         }
-
-        return new File(output.makeDirectories().path());
     }
 
 

--- a/src/config.js
+++ b/src/config.js
@@ -193,6 +193,7 @@ module.exports = function () {
             });
 
             let defaultOptions = {
+                sourceMaps: Config.sourcemaps && (Mix.inProduction() ? true : 'both'),
                 cacheDirectory: true,
                 presets: [
                     ['env', {

--- a/src/tasks/ConcatenateFilesTask.js
+++ b/src/tasks/ConcatenateFilesTask.js
@@ -16,7 +16,11 @@ class ConcatenateFilesTask extends Task {
      * Merge the files into one.
      */
     merge() {
-        const mergedFiles = this.files.merge(this.data.output, this.data.babel);
+        const mergedFiles = this.files.merge(
+          this.data.output,
+          this.data.babel,
+          this.data.skipSourceMaps
+        );
         if (Array.isArray(mergedFiles)) {
           this.assets.push(...mergedFiles);
         } else {

--- a/src/tasks/ConcatenateFilesTask.js
+++ b/src/tasks/ConcatenateFilesTask.js
@@ -16,9 +16,12 @@ class ConcatenateFilesTask extends Task {
      * Merge the files into one.
      */
     merge() {
-        this.assets.push(
-            this.files.merge(this.data.output, this.data.babel)
-        );
+        const mergedFiles = this.files.merge(this.data.output, this.data.babel);
+        if (Array.isArray(mergedFiles)) {
+          this.assets.push(...mergedFiles);
+        } else {
+          this.assets.push(mergedFiles);
+        }
     }
 
 


### PR DESCRIPTION
With this PR [babel-concat](https://github.com/luigi-rosso/babel-concat) is used when using `combine()` of JS files together with `.sourceMaps()`

Inline & `.map` sourceMaps are generated for proper debugging and "jump-to-source" in JS dev tools.

I don't expect this PR to be merged in the current state but I think this feature might be interesting for others and maybe a better implementation could be merged sometime.

- babel is probably an overkill for the sole purpose of source-maps. Combining is slower.
_Combining can be disabled by setting `skipSourceMaps` to true for specific files_

- babel-concat seems abandoned and a more up-to-date fork has to be used    
_It does not contain a lot code so the sourceMap generating part could be extracted and used without babel. It uses the official mozilla [source-map](https://github.com/mozilla/source-map) lib. It could also be swapped with something like [concat-with-sourcemaps](https://github.com/floridoo/concat-with-sourcemaps)_

- babel does not work with css files.


Off Topic: Is there any documentation on how to run the tests of this repo? nyc/ava doesn't find any tests (config file not in repo?). Probably I'm doing something wrong. Some kind of contribution guide would be really helpful.