### PR TITLE
Enable standalone postcss

### DIFF
--- a/src/Api.js
+++ b/src/Api.js
@@ -142,6 +142,16 @@ class Api {
 
 
     /**
+     * Register postcss compilation.
+     *
+     * @param {string} src
+     * @param {string} output
+     */
+    postcss(src, output) {
+        return this.preprocess('postcss', src, output);
+    };
+
+    /**
      * Register a generic CSS preprocessor.
      *
      * @param {string} type

--- a/src/builder/webpack-rules.js
+++ b/src/builder/webpack-rules.js
@@ -31,6 +31,7 @@ module.exports = function () {
     // CSS Compilation.
     rules.push({
         test: /\.css$/,
+        exclude: Config.preprocessors.postcss ? Config.preprocessors.postcss.map(postcss => postcss.src.path()) : [],
         loaders: ['style-loader', 'css-loader']
     });
 
@@ -162,13 +163,15 @@ module.exports = function () {
                     });
                 }
 
-                loaders.push({
-                    loader: `${type}-loader`,
-                    options: Object.assign(
-                        preprocessor.pluginOptions,
-                        { sourceMap: (type === 'sass' && Config.processCssUrls) ? true : Mix.isUsing('sourcemaps') }
-                    )
-                });
+                if (type !== 'postcss') {
+                    loaders.push({
+                        loader: `${type}-loader`,
+                        options: Object.assign(
+                            preprocessor.pluginOptions,
+                            { sourceMap: (type === 'sass' && Config.processCssUrls) ? true : Mix.isUsing('sourcemaps') }
+                        )
+                    });
+                }
 
                 rules.push({
                     test: preprocessor.src.path(),


### PR DESCRIPTION
This PR adds a `postcss` method to the Mix API, which doesn't use any preprocessor except PostCSS.

Overview:
- Added `postcss` to the public API
- Files processed this way are excluded by the `css-loader` to avoid duplicate loading (which throws an error)
- PostCSS is already used for the preprocessors, so added an exception when registering the preprocessor loader.

As far as I know, this is non-breaking because it's all behind the new API method.

This PR would resolve #728.