### PR TITLE
Update notification setting for onSuccess() method

### DIFF
--- a/src/StandaloneSass.js
+++ b/src/StandaloneSass.js
@@ -112,7 +112,7 @@ class StandaloneSass {
         console.log("\n");
         console.log(output);
 
-        if (Mix.isUsing('notifications')) {
+        if (Mix.isUsing('notificationsOnSuccess')) {
             notifier.notify({
                 title: 'Laravel Mix',
                 message: 'Sass Compilation Successful',


### PR DESCRIPTION
This stops `standaloneSass()` from displaying success messages on compile, when you are using the `disableSuccessNotifications()` method in your `webpack.mix.js` file.