### PR TITLE
Support importing .vue files using typescript

### DIFF
--- a/src/builder/webpack-rules.js
+++ b/src/builder/webpack-rules.js
@@ -24,6 +24,9 @@ module.exports = function () {
             test: /\.tsx?$/,
             loader: 'ts-loader',
             exclude: /node_modules/,
+            options: {
+                appendTsSuffixTo: [/\.vue$/],
+            }
         });
     }
 


### PR DESCRIPTION
In order to import typescript definitions from .vue files, an additional configuration option is necessary when declaring the 'ts-loader'.

Until this pull request is not merged, it is necessary to add the following to mix configuration in order to have this feature working:

    .webpackConfig({
        module: {
            rules: [
                {
                    test: /\.tsx?$/,
                    loader: 'ts-loader',
                    exclude: /node_modules/,
                    options: {
                        appendTsSuffixTo: [/\.vue$/]
                    }
                }
            ]
        }
    })

This approach is also used on both the following templates, so I think it would be a good idea to have this in laravel mix enabled by default:
https://github.com/Microsoft/TypeScript-Vue-Starter/blob/master/webpack.config.js
https://github.com/vuejs/vue-class-component/blob/master/example/webpack.config.js