### PR TITLE
Update quick-webpack-configuration.md

### DIFF
--- a/docs/quick-webpack-configuration.md
+++ b/docs/quick-webpack-configuration.md
@@ -17,6 +17,7 @@ Below, as an example, we'll add a custom module path for Laravel Spark.
 mix.webpackConfig({
     resolve: {
         modules: [
+            'node_modules',
             path.resolve(__dirname, 'vendor/laravel/spark/resources/assets/js')
         ]
     }


### PR DESCRIPTION
In webpack 2, the default for `resolve.modules` is ['node_modules'], but this is only populated if `resolve.modules` is empty in the config.  That means if you want to provide your own `resolve.modules`, you also need to add in `node_modules` to the array b/c web pack will not add it itself; i.e.: you need to add the default back in.