### PR TITLE
Replace the --save-dev flag with --dev when using Yarn

### DIFF
--- a/src/Verify.js
+++ b/src/Verify.js
@@ -101,7 +101,7 @@ class Verify {
             );
 
             if (File.exists('yarn.lock')) {
-                installCommand = installCommand.replace('npm install', 'yarn add');
+                installCommand = installCommand.replace('npm install', 'yarn add').replace('--save-dev', '--dev');
             }
 
             exec(installCommand);


### PR DESCRIPTION
If you use Yarn to install your dependencies, then use a plugin that requires extra dependencies, they will not be placed under `devDependencies`. 

This happens because the `--save-dev` flag is not recognized by Yarn. When doing the replace of `npm install` with `yarn add`, we must also update the save flag. 