### PR TITLE
chore(deps): Pin latest webpack 3.4 dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "uglifyjs-webpack-plugin": "^0.4.6",
     "vue-loader": "^12.1.1",
     "vue-template-compiler": "^2.3.3",
-    "webpack": "^3.3.0",
+    "webpack": "^3.4.0",
     "webpack-chunk-hash": "^0.4.0",
     "webpack-dev-server": "^2.5.1",
     "webpack-merge": "^4.1.0",


### PR DESCRIPTION
This pins a minor version update from webpack 3.3 to 3.4. We have a considerable amount of bug fixes and build perf improvements. Tests seemed to pass locally but maybe check just for sure.