### PR TITLE
Fix HMR on Windows when extracting vendor libraries

### DIFF
--- a/src/builder/Entry.js
+++ b/src/builder/Entry.js
@@ -63,9 +63,17 @@ class Entry {
             );
         }
 
+        let getPathJoin = (vendorPath) => {
+            if (process.platform === 'win32') {
+                return vendorPath.replace(/\\/g, '\\');
+            }
+
+            return vendorPath.replace(/\\/g, '/');
+        }
+
         let vendorPath = extraction.output
             ? new File(extraction.output).pathFromPublic(Config.publicPath).replace(/\.js$/, '')
-            : path.join(this.base, 'vendor').replace(/\\/g, '/');
+            : getPathJoin(path.join(this.base, 'vendor'));
 
         this.add(vendorPath, extraction.libs);
 


### PR DESCRIPTION
When extracting vendor libraries (following the current docs, where `extract()` is just specifying an array for the libs), vendor.js will be seemingly left out -- 404's from the node server on 8080.

Even though Windows should be able to handle different slashes, vendor.js would act as if it doesn't exist.

