### PR TITLE
Add cross-env to support other environment

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -59,9 +59,9 @@ As a tip, consider adding the following NPM scripts to your `package.json` file,
 
 ```js
   "scripts": {
-    "dev": "NODE_ENV=development webpack --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js",
-    "watch": "NODE_ENV=development webpack --watch --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js",
-    "hot": "NODE_ENV=development webpack-dev-server --inline --hot --config=node_modules/laravel-mix/setup/webpack.config.js",
-    "production": "NODE_ENV=production webpack --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js"
+    "dev": "cross-env NODE_ENV=development webpack --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js",
+    "watch": "cross-env NODE_ENV=development webpack --watch --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js",
+    "hot": "cross-env NODE_ENV=development webpack-dev-server --inline --hot --config=node_modules/laravel-mix/setup/webpack.config.js",
+    "production": "cross-env NODE_ENV=production webpack --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js"
   }
 ```

--- a/package.json
+++ b/package.json
@@ -4,10 +4,10 @@
   "description": "Laravel Mix is an elegant wrapper around Webpack for the 80% use case.",
   "main": "src/index.js",
   "scripts": {
-    "webpack": "NODE_ENV=development webpack --progress --hide-modules",
-    "dev": "NODE_ENV=development webpack --watch --progress --hide-modules",
-    "hmr": "NODE_ENV=development webpack-dev-server --inline --hot",
-    "production": "NODE_ENV=production webpack --progress --hide-modules",
+    "webpack": "cross-env NODE_ENV=development webpack --progress --hide-modules",
+    "dev": "cross-env NODE_ENV=development webpack --watch --progress --hide-modules",
+    "hmr": "cross-env NODE_ENV=development webpack-dev-server --inline --hot",
+    "production": "cross-env NODE_ENV=production webpack --progress --hide-modules",
     "test": "sudo nyc ava --verbose",
     "posttest": "nyc report --reporter=html"
   },
@@ -65,6 +65,7 @@
   },
   "devDependencies": {
     "ava": "^0.19.1",
+    "cross-env": "^5.0.1",
     "mock-fs": "^4.3.0",
     "mock-require": "^2.0.2",
     "nyc": "^10.3.2",


### PR DESCRIPTION
I added cross-env to support other environment - The command NODE_ENV=development (etc.) on the NPM scripts does not work on windows. Using cross-env helps resolve that issue.