### PR TITLE
Dispatch event after building webpack config

### DIFF
--- a/src/builder/WebpackConfig.js
+++ b/src/builder/WebpackConfig.js
@@ -27,6 +27,8 @@ class WebpackConfig {
             .buildResolving()
             .mergeCustomConfig();
 
+        Mix.dispatch('configReady', this.webpackConfig);
+
         return this.webpackConfig;
     }
 


### PR DESCRIPTION
This implements #1006 

Allows the following syntax to freely modify the webpack config without the limitations of the `webpack-merge` smart merge.

Example:

```js
// webpack.mix.js

Mix.listen('configReady', (webpackConfig) => {

  // remove original rule
  webpackConfig.module.rules = webpackConfig.module.rules.filter(rule => String(rule.test) !== String(/\.s[ac]ss$/))

  // add modified rule
  webpackConfig.module.rules.push({
    test: /\.s[ac]ss$/,
    loaders: [
      {loader: 'style-loader'},
      {loader: 'css-loader', options: {sourceMap: true}},
      {loader: 'sass-loader', options: {sourceMap: true}},
    ],
  })

})
```