### PR TITLE
upgrade vue-template-compiler version

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "uglify-js": "^2.8.28",
     "uglifyjs-webpack-plugin": "^0.4.6",
     "vue-loader": "^12.1.1",
-    "vue-template-compiler": "^2.3.3",
+    "vue-template-compiler": "^2.4.2",
     "webpack": "^3.4.0",
     "webpack-chunk-hash": "^0.4.0",
     "webpack-dev-server": "^2.5.1",


### PR DESCRIPTION
I tried deleting `node_modules`, but still getting: 

```
Module build failed: Error:

Vue packages version mismatch:

- vue@2.4.2
- vue-template-compiler@2.3.3
```