### PR TITLE
fix: Fix standaloneSass compile method spawn destination to node-sass

### DIFF
--- a/src/StandaloneSass.js
+++ b/src/StandaloneSass.js
@@ -38,7 +38,7 @@ class StandaloneSass {
      */
     compile(watch = false) {
         this.command = spawn(
-            'node_modules/node-sass/bin/node-sass', [
+            path.resolve('./node_modules/.bin/node-sass'), [
                 this.src.path(),
                 this.output.path()
             ].concat(this.options(watch)), { shell: true }


### PR DESCRIPTION
As I offered in my comment on https://github.com/JeffreyWay/laravel-mix/commit/2a19746e7dabaca34885616830c018d13954e483#commitcomment-23415103 this is working properly on windows as the .bin folder holds both windows and unix executables.