### PR TITLE
RejectFilesFromManifest task for rejecting compiled files from manifest

### DIFF
--- a/src/Api.js
+++ b/src/Api.js
@@ -2,6 +2,7 @@ let Verify = require('./Verify');
 let CopyFilesTask = require('./tasks/CopyFilesTask');
 let ConcatFilesTask = require('./tasks/ConcatenateFilesTask');
 let VersionFilesTask = require('./tasks/VersionFilesTask');
+let RejectFilesFromManifest = require('./tasks/RejectFilesFromManifest');
 let glob = require('glob');
 let _ = require('lodash');
 
@@ -333,6 +334,33 @@ class Api {
 
         Mix.addTask(
             new VersionFilesTask({ files })
+        );
+
+        return this;
+    }
+
+    /**
+     * Reject files from manifest output.
+     *
+     * @param {Array} files
+     */
+    reject(files = []) {
+
+        files = flatten([].concat(files).map(filePath => {
+            if (File.find(filePath).isDirectory()) {
+                filePath += (path.sep + '**/*');
+            }
+
+            if (! filePath.includes('*')) return filePath;
+
+            return glob.sync(
+                new File(filePath).forceFromPublic().relativePath(),
+                { nodir: true }
+            );
+        }));
+
+        Mix.addTask(
+            new RejectFilesFromManifest({ files: files })
         );
 
         return this;

--- a/src/tasks/RejectFilesFromManifest.js
+++ b/src/tasks/RejectFilesFromManifest.js
@@ -1,0 +1,42 @@
+let Task = require('./Task');
+let FileCollection = require('../FileCollection');
+
+class RejectFilesFromManifest extends Task {
+    /**
+     * Run the task.
+     */
+    run() {
+        this.files = new FileCollection(this.data.files);
+
+        this.cleanManifest();
+
+        Mix.manifest.refresh();
+    }
+
+    /**
+     * Removes the rejected files from manifest file.
+     */
+    cleanManifest() {
+        var manifest = Mix.manifest.read();
+
+        for (let filename in manifest) {
+            for (let index in this.files) {
+                if (filename.indexOf(this.files[index]) !== -1) {
+                    delete manifest[filename];
+                }
+            }
+        }
+
+        Mix.manifest.manifest = manifest;
+    }
+
+    /**
+     * Handle when a relevant source file is changed.
+     *
+     * @param {string} updatedFile
+     */
+    onChange(updatedFile) {
+    }
+}
+
+module.exports = RejectFilesFromManifest;

--- a/src/tasks/RejectFilesFromManifest.js
+++ b/src/tasks/RejectFilesFromManifest.js
@@ -9,8 +9,6 @@ class RejectFilesFromManifest extends Task {
         this.files = new FileCollection(this.data.files);
 
         this.cleanManifest();
-
-        Mix.manifest.refresh();
     }
 
     /**


### PR DESCRIPTION
Hey Jeffrey,

I just had some problems with temp files being added to the manifest json file so I added a new task called "RejectFilesFromManifest" for rejecting files from being added to the manifest json file.

Example:
```javascript
let mix = require('laravel-mix');

mix.sass('src/file1.sass', 'dist/temp1.css')
    .sass('src/file2.sass', 'dist/temp2.css')
    .styles([
        'dist/temp1.css',
        'dist/temp2.css',
    ], 'dist/concatenated.css')
    .reject([
        'dist/temp1.css',
        'dist/temp2.css',
    ])
    .version();
```

Now (using the reject() method) the manifest json file will contain only the 'dist/concatenated.css' file and not the temp compiled sass files ('dist/temp1.css', 'dist/temp2.css').