### PR TITLE
Allow file-loader (image and font) directories to be customised - resolves #1090

### DIFF
--- a/src/builder/webpack-rules.js
+++ b/src/builder/webpack-rules.js
@@ -72,10 +72,10 @@ module.exports = function () {
                 options: {
                     name: path => {
                         if (! /node_modules|bower_components/.test(path)) {
-                            return 'images/[name].[ext]?[hash]';
+                            return Config.fileLoaderDirs.images + '/[name].[ext]?[hash]';
                         }
 
-                        return 'images/vendor/' + path
+                        return Config.fileLoaderDirs.images + '/vendor/' + path
                             .replace(/\\/g, '/')
                             .replace(
                                 /((.*(node_modules|bower_components))|images|image|img|assets)\//g, ''
@@ -100,10 +100,10 @@ module.exports = function () {
         options: {
             name: path => {
                 if (! /node_modules|bower_components/.test(path)) {
-                    return 'fonts/[name].[ext]?[hash]';
+                    return Config.fileLoaderDirs.fonts + '/[name].[ext]?[hash]';
                 }
 
-                return 'fonts/vendor/' + path
+                return Config.fileLoaderDirs.fonts + '/vendor/' + path
                     .replace(/\\/g, '/')
                     .replace(
                         /((.*(node_modules|bower_components))|fonts|font|assets)\//g, ''

--- a/src/config.js
+++ b/src/config.js
@@ -174,6 +174,17 @@ module.exports = function () {
 
 
         /**
+        * File Loader directory defaults.
+        *
+        * @type {Object}
+        */
+        fileLoaderDirs: {
+            images: 'images',
+            fonts: 'fonts'
+        },
+
+
+        /**
          * The default Babel configuration.
          *
          * @type {Object}


### PR DESCRIPTION
This change allows setting the output directories for assets processed by the the file-loader - at the moment only images and fonts:

```js
mix.options({
  fileLoaderDirs: {
    images: 'img',
    fonts: 'web-fonts'
  }
});
```

Previously you'd have to remove the existing rules and add a modified version by listening to `configReady` and modifying `webpackConfig` directly - too much boilerplate, and not update-proof.

I think these options are especially necessary because the `webpack.config.js` file isn't left in the project root.

Resolves #1090.