### PR TITLE
#1024 Add globalVueStyles configuration option

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -15,6 +15,7 @@ mix.options({
 A handful of Mix options and overrides are available, should you require them. Please take note of the options above, as well as their default values. Here's a quick overview:
 
 - **extractVueStyles:** Extract `.vue` component styling (CSS within `<style>` tags) to a dedicated file, rather than inlining it into the HTML.
+- **globalVueStyles:** Indicate a file to include in every component styles. This file should only include variables, functions or mixins in order to prevent duplicated css in your final, compiled files. This option only works when `extractVueStyles` is enabled and requires [sass-resources-loader](https://github.com/shakacode/sass-resources-loader) package to be installed.
 - **processCssUrls:** Process/optimize relative stylesheet url()'s. By default, Webpack will automatically update these URLs, when relevant. If, however, your folder structure is already organized the way you want it, set this option to `false` to disable processing.
 - **uglify:** Use this option to merge any [custom Uglify options](https://webpack.github.io/docs/list-of-plugins.html#uglifyjsplugin) that your project requires.
 - **purifyCss:** Set this option to `true` if you want Mix to automatically read your HTML/Blade files and strip your CSS bundle of all unused selectors. You can also pass an object containing [purifycss-webpack options](https://github.com/webpack-contrib/purifycss-webpack#options).

--- a/setup/webpack.mix.js
+++ b/setup/webpack.mix.js
@@ -40,6 +40,7 @@ mix.js('src/app.js', 'dist/')
 // mix.then(function () {}) <-- Will be triggered each time Webpack finishes building.
 // mix.options({
 //   extractVueStyles: false, // Extract .vue component styling to file, rather than inline.
+//   globalVueStyles: file, // Variables file to be imported in every component.
 //   processCssUrls: true, // Process/optimize relative stylesheet url()'s. Set to false, if you don't want them touched.
 //   purifyCss: false, // Remove unused CSS selectors.
 //   uglify: {}, // Uglify-specific options. https://webpack.github.io/docs/list-of-plugins.html#uglifyjsplugin

--- a/src/builder/webpack-rules.js
+++ b/src/builder/webpack-rules.js
@@ -253,5 +253,24 @@ module.exports = function () {
         extractPlugins.push(vueExtractPlugin);
     }
 
+    // If we want to import a global styles file in every component,
+    // use sass resources loader
+    if (Config.extractVueStyles && Config.globalVueStyles) {
+        tap(rules[rules.length - 1].options.loaders, vueLoaders => {
+            vueLoaders.scss.push({
+                loader: 'sass-resources-loader',
+                options: {
+                  resources: Mix.paths.root(Config.globalVueStyles)
+                }
+            });
+            vueLoaders.sass.push({
+                loader: 'sass-resources-loader',
+                options: {
+                  resources: Mix.paths.root(Config.globalVueStyles)
+                }
+            });
+        });
+    }
+
     return { rules, extractPlugins };
 }

--- a/src/config.js
+++ b/src/config.js
@@ -225,6 +225,16 @@ module.exports = function () {
 
 
         /**
+        * File with global styles to be imported in every component.
+        *
+        * See: https://vue-loader.vuejs.org/en/configurations/pre-processors.html#loading-a-global-settings-file
+        *
+        * @type {string}
+        */
+        globalVueStyles: '',
+
+
+        /**
          * Uglify-specific settings for Webpack.
          *
          * See: https://github.com/mishoo/UglifyJS2#compressor-options


### PR DESCRIPTION
Proposal to solve issue #1024

Having a global sass file with variables, mixins and functions is a common scenario, and right now the only option to use such file in .vue component files is importing it manually every time. From the vue-loader documentation we can see how they recommend solving this: [Loading a global settings file](https://vue-loader.vuejs.org/en/configurations/pre-processors.html#loading-a-global-settings-file)

Having all this into account, I think it'd be sensible to have such an option in the mix manifest.