### PR TITLE
Added inline documentation for mix.ts

### DIFF
--- a/setup/webpack.mix.js
+++ b/setup/webpack.mix.js
@@ -17,6 +17,7 @@ mix.js('src/app.js', 'dist/')
 // Full API
 // mix.js(src, output);
 // mix.react(src, output); <-- Identical to mix.js(), but registers React Babel compilation.
+// mix.ts(src, output); <-- Requires tsconfig.json to exist in the same folder as webpack.mix.js
 // mix.extract(vendorLibs);
 // mix.sass(src, output);
 // mix.standaloneSass('src', output); <-- Faster, but isolated from Webpack.


### PR DESCRIPTION
TypeScript has been officially supported since laravel-mix version 1.0, but its never been documented in the webpack.mix.js file. Now it is. 