### PR TITLE
Autoprefix after handling other PostCSS plugins

### DIFF
--- a/src/builder/webpack-rules.js
+++ b/src/builder/webpack-rules.js
@@ -135,6 +135,14 @@ module.exports = function () {
             let outputPath = preprocessor.output.filePath.replace(Config.publicPath + path.sep, path.sep);
 
             tap(new ExtractTextPlugin(outputPath), extractPlugin => {
+                let postCssPlugins = Config.postCss;
+
+                if (preprocessor.postCssPlugins && preprocessor.postCssPlugins.length) {
+                    postCssPlugins = preprocessor.postCssPlugins;
+                }
+
+                postCssPlugins.push(require('autoprefixer'));
+                
                 let loaders = [
                     {
                         loader: 'css-loader',
@@ -150,13 +158,7 @@ module.exports = function () {
                         options: {
                             sourceMap: (type === 'sass' && Config.processCssUrls) ? true : Mix.isUsing('sourcemaps'),
                             ident: 'postcss',
-                            plugins: [
-                                require('autoprefixer')
-                            ].concat(
-                                preprocessor.postCssPlugins && preprocessor.postCssPlugins.length
-                                    ? preprocessor.postCssPlugins
-                                    : Config.postCss
-                            )
+                            plugins: postCssPlugins,
                         }
                     },
                 ];


### PR DESCRIPTION
Autoprefixing should happen after all other css processing, other wise it isn't necessarily applied to all your css rules.

In my opinion, autoprefixer shouldn't be enabled at all when you pass a custom PostCSS config, so you can decide for yourself where it belongs, but that would be a breaking change for some.