### PR TITLE
Yarn should save to devDependencies

### DIFF
--- a/src/Verify.js
+++ b/src/Verify.js
@@ -121,7 +121,7 @@ let installDependencies = dependencies => {
     let command = `npm install ${dependencies} --save-dev`;
 
     if (File.exists('yarn.lock')) {
-        command = `yarn add ${dependencies} --save`;
+        command = `yarn add ${dependencies} --dev`;
     }
 
     exec(command);


### PR DESCRIPTION
[yarn add](https://yarnpkg.com/en/docs/cli/add) doesn't need the `--save` flag to update the `package.json`, but does need the `--dev` flag to save to devDependencies instead of dependencies.