### PR TITLE
Add esModule: false to vue-loader options for compatibility with vue files loaded using require().

### DIFF
--- a/src/builder/webpack-rules.js
+++ b/src/builder/webpack-rules.js
@@ -243,7 +243,8 @@ module.exports = function () {
             },
             postcss: Config.postCss,
             preLoaders: Config.vue.preLoaders,
-            postLoaders: Config.vue.postLoaders
+            postLoaders: Config.vue.postLoaders,
+            esModule: false
         }
     });
 


### PR DESCRIPTION
Add esModule: false to vue-loader options for compatibility with vue files loaded using require(). Related: #1206 