### PR TITLE
Fix minor versioning issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "style-loader": "^0.18.1",
     "uglify-js": "^2.8.28",
     "uglifyjs-webpack-plugin": "^0.4.6",
+    "vue": "^2.4.4",
     "vue-loader": "^13.0.5",
     "vue-template-compiler": "^2.4.4",
     "webpack": "^3.5.0",

--- a/src/File.js
+++ b/src/File.js
@@ -178,7 +178,7 @@ class File {
      */
     read() {
         const path = this.path();
-        let realPath = (path.startsWith(Mix.paths.rootPath))? path : `${Mix.paths.rootPath}${path}`;
+        const realPath = (path.startsWith(Mix.paths.rootPath))? path : `${Mix.paths.rootPath}${path}`;
 
         return fs.readFileSync(realPath, {
             encoding: 'utf-8'

--- a/src/File.js
+++ b/src/File.js
@@ -177,7 +177,10 @@ class File {
      * Read the file's contents.
      */
     read() {
-        return fs.readFileSync(this.path(), {
+        const path = this.path();
+        let realPath = (path.startsWith(Mix.paths.rootPath))? path : `${Mix.paths.rootPath}${path}`;
+
+        return fs.readFileSync(realPath, {
             encoding: 'utf-8'
         });
     }


### PR DESCRIPTION
When versioning files sometimes the files path would appear to be a relative path prefixed with / causing an error in locating the file to be versioned.

EG : #1235 

This small fix checks to see if a file's path starts with mix's root path and if it doesn't it prefixes it so that an absolute path can be created and the real file can be found by the fs module.

Also added vue to the package.json file as without it the test suite was failing.