### PR TITLE
Allow Vue style file name/path to be specified

### DIFF
--- a/src/builder/webpack-rules.js
+++ b/src/builder/webpack-rules.js
@@ -198,7 +198,7 @@ module.exports = function () {
     let vueExtractPlugin;
 
     if (Config.extractVueStyles) {
-        vueExtractPlugin = extractPlugins.length ? extractPlugins[0] : new ExtractTextPlugin('vue-styles.css');
+        vueExtractPlugin = extractPlugins.length ? extractPlugins[0] : new ExtractTextPlugin((typeof(Config.extractVueStyles) === "string") ? Config.extractVueStyles : 'vue-styles.css');
     }
 
     rules.push({

--- a/src/builder/webpack-rules.js
+++ b/src/builder/webpack-rules.js
@@ -198,7 +198,9 @@ module.exports = function () {
     let vueExtractPlugin;
 
     if (Config.extractVueStyles) {
-        vueExtractPlugin = extractPlugins.length ? extractPlugins[0] : new ExtractTextPlugin((typeof(Config.extractVueStyles) === "string") ? Config.extractVueStyles : 'vue-styles.css');
+        let fileName = typeof(Config.extractVueStyles) === "string" ? Config.extractVueStyles : 'vue-styles.css';
+        let filePath = fileName.replace(Config.publicPath, '').replace(/^\//, "");
+        vueExtractPlugin = extractPlugins.length ? extractPlugins[0] : new ExtractTextPlugin(filePath);
     }
 
     rules.push({


### PR DESCRIPTION
Currently, if you want to abstract your .vue file styles, you can't choose the name of that file or its location.

Before the recent refactor, you could do it like this:

```
mix.options({
  extractVueStyles: 'public/css/vue-style.css'
});
```

I've restored that feature in this PR.