### PR TITLE
Fix failing test by adapting it to new conditions

### DIFF
--- a/test/config.js
+++ b/test/config.js
@@ -15,14 +15,14 @@ test('that it can merge config', t => {
 test('that it intelligently builds the Babel config', t => {
     // Given the user has a custom .babelrc file...
     new File('.babelrc').write({
-        'plugins': ['transform-object-rest-spread']
+        'plugins': ['arbitrary-plugin']
     });
 
     // And we construct the Babel config for Mix...
     let options = Config.babel();
 
     // Then it should smartly merge the user's .babelrc with Mix's.
-    t.deepEqual(['transform-object-rest-spread'], options.plugins)
+    t.deepEqual(['transform-object-rest-spread', 'arbitrary-plugin'], options.plugins)
     t.is('env', options.presets[0][0]);
 
     // Clean up.


### PR DESCRIPTION
The test failed, because there were two entries
'transform-object-rest-spread' in the options.plugins array.

This has most likely to do with src/config.js which declares
'transform-object-rest-spread' as a default plugin.