### PR TITLE
Fix failing test by adapting it to new conditions

### DIFF
--- a/test/Api.js
+++ b/test/Api.js
@@ -272,7 +272,7 @@ test('mix.sourceMaps()', t => {
 
     // Sourcemaps should use a sensible type as the default for dev.
     t.is(mix, response);
-    t.is('cheap-module-eval-source-map', Config.sourcemaps);
+    t.is('inline-source-map', Config.sourcemaps);
 
     // For production builds, we should use a more performant type.
     Config.production = true;


### PR DESCRIPTION
The test failed because it expected 'cheap-module-eval-source-map'
instead of the actual 'inline-source-map'.