### PR TITLE
Make project work out of the box without laravel

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -109,7 +109,7 @@ module.exports = function () {
          *
          * @type {String}
          */
-        publicPath: '',
+        publicPath: 'public',
 
 
         /**


### PR DESCRIPTION
Before this change, on windows machines, the code would throw an error out of the box. With this change, everything works smoothly as it should, and can be used on all platforms without needing to search for the fix.