### PR TITLE
Bump Vue to 2.5.0 and set vue-template-compiler version 

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "uglify-js": "^2.8.28",
     "uglifyjs-webpack-plugin": "^0.4.6",
     "vue-loader": "^13.0.5",
-    "vue-template-compiler": "^2.4.4",
+    "vue-template-compiler": "^2.0.0",
     "webpack": "^3.5.0",
     "webpack-chunk-hash": "^0.4.0",
     "webpack-dev-server": "^2.5.1",
@@ -71,7 +71,7 @@
     "nyc": "^10.3.2",
     "postcss-custom-properties": "^6.2.0",
     "sinon": "^2.3.2",
-    "vue": "^2.4.4"
+    "vue": "^2.5.0"
   },
   "engines": {
     "node": ">=6.0.0"


### PR DESCRIPTION
Set vue-template-compiler to retrieve latest version based of v2.

Resolves #1263

Signed-off-by: Ru Chern Chong <ruchern@sproud.biz>