### PR TITLE
remove reference to Laravel 5.4

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -4,7 +4,7 @@ Though Laravel Mix is optimized for Laravel usage, it may be used for any type o
 
 ### Laravel Project
 
-Laravel 5.4 ships with everything you need to get started. Simply:
+Laravel ships with everything you need to get started. Simply:
 
 * Install Laravel
 * Run `npm install`


### PR DESCRIPTION
## Before
The installation docs refer to Laravel 5.4:
> Laravel 5.4 ships with everything you need to get started. Simply:

## After
Instead of having to keep this updated, I just dropped the version number.
> Laravel ships with everything you need to get started. Simply: