### PR TITLE
Add autoprefixer toggle to config

### DIFF
--- a/src/builder/webpack-rules.js
+++ b/src/builder/webpack-rules.js
@@ -157,7 +157,9 @@ module.exports = function () {
                                     plugins = preprocessor.postCssPlugins;
                                 }
 
-                                plugins.push(require('autoprefixer'));
+                                if (Config.autoprefixer) {
+                                    plugins.push(require('autoprefixer'));
+                                }
 
                                 return plugins;
                             })()

--- a/src/config.js
+++ b/src/config.js
@@ -92,6 +92,12 @@ module.exports = function () {
          */
         postCss: [],
 
+        /**
+         * Determine if we should enable autoprefixer by default.
+         *
+         * @type {Boolean}
+         */
+        autoprefixer: true,
 
         /**
          * Determine if Mix should remove unused selectors from your CSS bundle.


### PR DESCRIPTION
There are two cases in which including autoprefixer by default gets in the way:

- When you're using a postcss plugin which already includes autoprefixer (like cssnext)
- or when you want to pass some extra configuration to autoprefixer

This PR adds a config toggle for autoprefixer, `true` by default so it's non-breaking, but it allows you to disable it if you want to deal with autoprefixer yourself in your project.