### PR TITLE
 update uglifyjs-webpack-plugin to ^1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "sass-loader": "^6.0.5",
     "style-loader": "^0.18.1",
     "uglify-js": "^2.8.28",
-    "uglifyjs-webpack-plugin": "^0.4.6",
+    "uglifyjs-webpack-plugin": "^1.0.0",
     "vue-loader": "^13.0.5",
     "vue-template-compiler": "^2.0.0",
     "webpack": "^3.5.0",

--- a/src/config.js
+++ b/src/config.js
@@ -245,13 +245,15 @@ module.exports = function () {
          * @type {Object}
          */
         uglify: {
-            sourceMap: true,
-            compress: {
-                warnings: false,
-                drop_console: true,
-            },
-            output: {
-                comments: false
+            uglifyOptions: {
+                sourceMap: true,
+                compress: {
+                    warnings: false,
+                    drop_console: true,
+                },
+                output: {
+                    comments: false
+                }
             }
         },
 


### PR DESCRIPTION
uglifyjs-webpack-plugin released the 1.0.0 version couple days ago:
https://github.com/webpack-contrib/uglifyjs-webpack-plugin/releases

the new version add es6 support, quite useful. 
