### PR TITLE
Fix uglify defaults - sourceMap

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -274,8 +274,8 @@ module.exports = function () {
          * @type {Object}
          */
         uglify: {
+            sourceMap: true,
             uglifyOptions: {
-                sourceMap: true,
                 compress: {
                     warnings: false,
                     drop_console: true,


### PR DESCRIPTION
sourceMap is standalone Uglify config option - https://github.com/webpack-contrib/uglifyjs-webpack-plugin#options

Also I see that "uglify/uglifyOptions/output/comments" is false by default - https://github.com/mishoo/UglifyJS2/tree/harmony#output-options and same for "uglify/uglifyOptions/compress/warnings" is also false by default - https://github.com/mishoo/UglifyJS2/tree/harmony#compress-options but I do not removed these.

Last I noticed that in default config sourceMap has "@type {Boolean}" and default value false. But I can not set true for this option. Alowed is only string or false - https://webpack.js.org/configuration/devtool/ . Maybe would be good idea to catch true value in this setting and set up one from allowed sourceMap string options.