### PR TITLE
Update node-sass version in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "img-loader": "^2.0.0",
     "lodash": "^4.17.4",
     "md5": "^2.2.1",
-    "node-sass": "4.5.3",
+    "node-sass": "4.7.2",
     "postcss-loader": "^2.0.5",
     "resolve-url-loader": "^2.0.2",
     "sass-loader": "^6.0.5",


### PR DESCRIPTION
Old version listed of node-sass (4.5.3) is no longer available at its known remote address, causing a clean npm install to break as laravel-mix still refers to it. Updating to 4.7.2 (as done for Bootstrap 4 beta 2), should solve this.