### PR TITLE
vueExtractPlugin can use a function

### DIFF
--- a/src/builder/webpack-rules.js
+++ b/src/builder/webpack-rules.js
@@ -202,9 +202,20 @@ module.exports = function () {
     let vueExtractPlugin;
 
     if (Config.extractVueStyles) {
-        let fileName = typeof(Config.extractVueStyles) === "string" ? Config.extractVueStyles : 'vue-styles.css';
-        let filePath = fileName.replace(Config.publicPath, '').replace(/^\//, "");
-        vueExtractPlugin = extractPlugins.length ? extractPlugins[0] : new ExtractTextPlugin(filePath);
+        let fileName = Config.extractVueStyles;
+        let filePath;
+        if (typeof (fileName) === "string") {
+            filePath = fileName.replace(Config.publicPath, '').replace(/^\//, "");
+        } else if (typeof (fileName) === "function") {
+            filePath = fileName;
+        } else {
+            filePath = 'vue-styles.css';
+        }
+        vueExtractPlugin = extractPlugins.length ? 
+            extractPlugins[0] : 
+            new ExtractTextPlugin({
+                filename: filePath
+            });
     }
 
     rules.push({


### PR DESCRIPTION
i think that vueExtractPlugin can use a function.
sometime,i have multiple entry js, i want export multiple css file, like this:
```
mix.options({
    extractVueStyles: '[name].css'

mix
.js('resources/assests/a/index.js', 'public/js/a.js')
.js('resources/assests/b/index.js', 'public/js/b.js');
```
This can generate two css files(a.css、b.css) in `public/js/` directory,but I want these two files are in another directory, like `public/css/`.

If i can use the function parameter,i can do that.
```
mix.options({
    extractVueStyles: function (getPath {
        return getPath('[name].css').replace('/js', '/css');
    }
}

mix
.js('resources/assests/a/index.js', 'public/js/a.js')
.js('resources/assests/b/index.js', 'public/js/b.js');
```
and `extract-text-webpack-plugin` can use function parameter
```
new ExtractTextPlugin(options: filename | object);
filename: {String\\|Function}
```

so, i pull request to solve this problem.

