### PR TITLE
Sort manifest key-value pairs by key

### DIFF
--- a/src/Manifest.js
+++ b/src/Manifest.js
@@ -26,7 +26,7 @@ class Manifest {
             );
         }
 
-        return this.manifest;
+        return sortObjectKeys(this.manifest);
     }
 
 

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -23,3 +23,13 @@ global.flatten = function (arr) {
         [], objectValues(arr)
     );
 };
+
+/**
+ * Sort object by keys
+ *
+ * @param {Object} obj
+ */
+global.sortObjectKeys = (obj) => {
+    return Object.keys(obj).sort()
+        .reduce((r, k) => (r[k] = obj[k], r), {});
+};

--- a/test/manifest.js
+++ b/test/manifest.js
@@ -63,3 +63,14 @@ test('it can be refreshed', t => {
 
     mockFs.restore();
 });
+
+test('it sorts files on the underlying manifest object', t => {
+    Mix.manifest.add('/path2.js');
+    Mix.manifest.add('/path3.js');
+    Mix.manifest.add('/path1.js');
+    Mix.manifest.add('/path4.js');
+
+    let manifest = Mix.manifest.get();
+
+    t.is(['/path1.js', '/path2.js','/path3.js','/path4.js'].join(), Object.keys(manifest).join())
+});


### PR DESCRIPTION
This PR will sort the resulted manifest json object by it's keys.

Sorting by keys can be useful for:

1- It's satisfying, nice to have, and similar to the auto sorting when `npm i --save/-dev`.

2- Git friendly. I'm not prepared now to explain how to reproduce a scenario that resulted in multiple changes to `manifest.json` that only related to its order.


----------


P.S: In the test I couldn't use `t.deepEqual` but instead:
``` js
    t.is(['/path1.js', '/path2.js','/path3.js','/path4.js'].join(), Object.keys(manifest).join())
```
Asserting the match between the joined-keys string due to an [issue in ava.deepEqual ignoring the order of properties](https://github.com/avajs/ava/issues/1232). I could get away with it using `t.deepEqual` the keys array -not the joined string-, but if `t.deepEqual` is changed later to ignore the array order, we wouldn't know.
