### PR TITLE
Production sourcemaps fix

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -276,6 +276,7 @@ module.exports = function () {
         uglify: {
             sourceMap: true,
             uglifyOptions: {
+                sourceMap: true,
                 compress: {
                     warnings: false,
                     drop_console: true,


### PR DESCRIPTION
It seems you also need to still add the `sourceMap: true` to the options.

https://github.com/mishoo/UglifyJS2/tree/harmony#source-map-options

The docs are not very clear about this because they want to be supplied with an Object but I have tried it with true and it seems to work.

If you don't set it, sourcemaps will fail in production:

https://github.com/JeffreyWay/laravel-mix/issues/1345

Try a clean Laravel installation and add:

```
mix.options({
    sourcemaps: 'source-map'
});
```

You will see that it will not create javascript sourcemaps when you run `npm run production` because it clashes with uglify.

This will work though:

```
mix.options({
    sourcemaps: 'source-map',
    uglify: {
        sourceMap: true,
        uglifyOptions: {
            sourceMap: true,
            compress: {
                warnings: false,
                drop_console: true,
            },
            output: {
                comments: false
            }
        }
    }
});
```

Please confirm this behavior, but it seems to fix the issue.