### PR TITLE
Updated devtool option to a full source-map

### DIFF
--- a/src/Api.js
+++ b/src/Api.js
@@ -377,7 +377,7 @@ class Api {
      */
     sourceMaps(productionToo = true, type = 'inline-source-map') {
         if (Mix.inProduction()) {
-            type = productionToo ? 'cheap-source-map' : false;
+            type = productionToo ? 'source-map' : false;
         }
 
         Config.sourcemaps = type;

--- a/src/Api.js
+++ b/src/Api.js
@@ -375,7 +375,7 @@ class Api {
      * @param {Boolean} productionToo
      * @param {string}  type
      */
-    sourceMaps(productionToo = true, type = 'inline-source-map') {
+    sourceMaps(productionToo = true, type = 'eval-source-map') {
         if (Mix.inProduction()) {
             type = productionToo ? 'source-map' : false;
         }


### PR DESCRIPTION
After reviewing the devtool options from Webpack the `cheap-source-map` option does not make much sense when wanting to have sourcemaps in production.

Sourcemaps in production are usually used for error reporting tools to unminify code within your error reporting tool. Tools like:

- Track.js
- Sentry
- Rollbar
- Etc.

The majority of Webpack plugins that provide support for these error reporting services default to `source-map` as the primary production devtool option. The Webpack documentation also specifies the `eval-source-map` option as follows:

> The following options are not ideal for development nor production.

https://webpack.js.org/configuration/devtool/#special-cases

On the other hand for the `source-map` option it states:

> These options are typically used in production

https://webpack.js.org/configuration/devtool/#production

A full source map provides `original code` quality which is needed for services like these, to work as efficiently as possible.

https://webpack.js.org/configuration/devtool/#devtool

If there are cases against using a full `source-map` for the devtool option in production I would love to hear them.

**Development sourcemap**

I have also updated the development default. `inline-source-map` is also specified under special cases whereas `eval-source-map` is specified for development. It has a slower initial build but faster rebuilds and also has original build quality for the mapping.

> It yields the best quality SourceMaps for development.