### PR TITLE
Add option to config mix based on the environment

### DIFF
--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -27,6 +27,22 @@ mix.js('resources/assets/js/app.js', 'public/js')
 
 By default, we've enabled JavaScript ES2017 + module bundling, as well as Sass compilation.
 
+#### *Optional Step 3*: Extended visit in `webpack.mix.js`
+
+You can also add some additional config options based on the current environment that Mix is running in.
+
+```js
+if(!mix.inProduction()) {
+    // Since we aren't in production add sourcemaps to the build
+    mix.sourceMaps();
+}
+
+if(mix.isEnvironment('development')) {
+    // Staging and Testing don't need browsersync enabled.
+    mix.browserSync('my-domain.dev');
+}
+```
+
 ### Step 4: Compilation
 
 Go ahead and compile these down.

--- a/src/Mix.js
+++ b/src/Mix.js
@@ -21,7 +21,7 @@ class Mix {
      * @param {string} tool
      */
     isUsing(tool) {
-        return !! Config[tool];
+        return !!Config[tool];
     }
 
 
@@ -30,6 +30,14 @@ class Mix {
      */
     inProduction() {
         return Config.production;
+    }
+
+
+    /**
+     * Determine if Mix is executing in a requested environment.
+     */
+    isEnvironment(env) {
+        return Config.env === env;
     }
 
 

--- a/src/config.js
+++ b/src/config.js
@@ -12,6 +12,14 @@ module.exports = function () {
 
 
         /**
+         * Sets the current environment.
+         *
+         * @type {String}
+         */
+        env: process.env.NODE_ENV,
+
+
+        /**
          * The list of scripts to bundle.
          *
          * @type {Array}

--- a/test/mix.js
+++ b/test/mix.js
@@ -17,6 +17,13 @@ test('that it knows if it is being executed in a production environment', t => {
 });
 
 
+test('that it knows if it is being executed in the development environment', t => {
+    Config.env = 'development';
+
+    t.true(Mix.isEnvironment('development'));
+});
+
+
 test('that it can check if a certain config item is truthy', t => {
     Config.versioning = true;
 


### PR DESCRIPTION
I needed some options beyond whether mix was in production or not. So I added an option for mix to check it's environment against an environment name provided by the user.

So you can now do something like...
```js
if(mix.isEnvironment('development')) { ... }
```