### PR TITLE
Allow for users to disable ExtractTextPlugins via an option

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "laravel-mix",
-  "version": "1.6.1",
+  "version": "1.7.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/builder/webpack-rules.js
+++ b/src/builder/webpack-rules.js
@@ -134,7 +134,10 @@ module.exports = function () {
         Config.preprocessors[type].forEach(preprocessor => {
             let outputPath = preprocessor.output.filePath.replace(Config.publicPath + path.sep, path.sep);
 
-            tap(new ExtractTextPlugin(outputPath), extractPlugin => {
+            tap(new ExtractTextPlugin({
+                filename: outputPath,
+                disable: Config.disableExtractPlugins
+            }), extractPlugin => {
                 let loaders = [
                     {
                         loader: 'css-loader',

--- a/src/config.js
+++ b/src/config.js
@@ -251,6 +251,12 @@ module.exports = function () {
          */
         processCssUrls: true,
 
+        /**
+         * Whether or not to disable the ExtractTextPlugins used in the config.
+         *
+         * @type {Boolean}
+         */
+        disableExtractPlugins: false,
 
         /**
          * Whether to extract .vue component styles into a dedicated file.


### PR DESCRIPTION
This allows for generated css files to be injected when using `npm run hot`.

To test: use a hot reloading setup, with a .sass() call. Change file and see injection as if you were using BrowserSync.