### PR TITLE
Distinguish between image SVG and font SVG

### DIFF
--- a/src/builder/webpack-rules.js
+++ b/src/builder/webpack-rules.js
@@ -65,7 +65,7 @@ module.exports = function () {
 
     // Add support for loading images.
     rules.push({
-        test: /\.(png|jpe?g|gif)$/,
+        test:  /(\.(png|jpe?g|gif)$|im[a]?g.*\.svg$)/,
         loaders: [
             {
                 loader: 'file-loader',
@@ -95,7 +95,7 @@ module.exports = function () {
 
     // Add support for loading fonts.
     rules.push({
-        test: /\.(woff2?|ttf|eot|svg|otf)$/,
+        test: /(\.(woff2?|ttf|eot|otf)$|font.*\.svg$)/,
         loader: 'file-loader',
         options: {
             name: path => {

--- a/src/builder/webpack-rules.js
+++ b/src/builder/webpack-rules.js
@@ -65,7 +65,8 @@ module.exports = function () {
 
     // Add support for loading images.
     rules.push({
-        test:  /(\.(png|jpe?g|gif)$|im[a]?g.*\.svg$)/,
+        // only include svg that doesn't have font in the path or file name by using negative lookahead
+        test:  /(\.(png|jpe?g|gif)$|^((?!font).)*\.svg$)/,
         loaders: [
             {
                 loader: 'file-loader',

--- a/test/features/mix.js
+++ b/test/features/mix.js
@@ -191,6 +191,20 @@ test.cb.serial('the kitchen sink', t => {
     });
 });
 
+test.cb.serial('it resolves image- and font-urls and distinguishes between them even if we deal with svg', t => {
+    // Given we have a sass file that refers to ../font.svg, ../font/awesome.svg and to ../img/img.svg
+    mix.sass('test/fixtures/fake-app/resources/assets/sass/font-and-image.scss', 'css');
+    // When we compile it
+    compile(t, () => {
+        // Then we expect the css to be built
+        t.true(File.exists('test/fixtures/fake-app/public/css/font-and-image.css'));
+        // Along with the referred image in the images folder
+        t.true(File.exists('test/fixtures/fake-app/public/images/img.svg'));
+        // And the referred fonts in the fonts folder
+        t.true(File.exists('test/fixtures/fake-app/public/fonts/font.svg'));
+        t.true(File.exists('test/fixtures/fake-app/public/fonts/awesome.svg'));
+    });
+});
 
 
 function compile(t, callback) {

--- a/test/features/mix.js
+++ b/test/features/mix.js
@@ -203,6 +203,11 @@ test.cb.serial('it resolves image- and font-urls and distinguishes between them 
         // And the referred fonts in the fonts folder
         t.true(File.exists('test/fixtures/fake-app/public/fonts/font.svg'));
         t.true(File.exists('test/fixtures/fake-app/public/fonts/awesome.svg'));
+        // And we expect the image NOT to be in the fonts folder:
+        t.false(File.exists('test/fixtures/fake-app/public/fonts/img.svg'));
+        // And the fonts NOT to be in the image folder
+        t.false(File.exists('test/fixtures/fake-app/public/images/font.svg'));
+        t.false(File.exists('test/fixtures/fake-app/public/images/awesome.svg'));
     });
 });
 

--- a/test/fixtures/fake-app/resources/assets/font.svg
+++ b/test/fixtures/fake-app/resources/assets/font.svg
@@ -1,0 +1,1 @@
+<!-- just a font file -->

--- a/test/fixtures/fake-app/resources/assets/font/awesome.svg
+++ b/test/fixtures/fake-app/resources/assets/font/awesome.svg
@@ -1,0 +1,1 @@
+<!-- just another font file -->

--- a/test/fixtures/fake-app/resources/assets/img/img.svg
+++ b/test/fixtures/fake-app/resources/assets/img/img.svg
@@ -1,0 +1,1 @@
+<!-- just an image file -->

--- a/test/fixtures/fake-app/resources/assets/sass/font-and-image.scss
+++ b/test/fixtures/fake-app/resources/assets/sass/font-and-image.scss
@@ -1,0 +1,25 @@
+// This scss shows how mix distinguishes between font SVG and image SVG.
+
+@font-face {
+  font-family: 'MyFont';
+  // If the path to an SVG contains "font", then the SVG will be copied to the fonts directory.
+  src: url("../font.svg#font") format("svg");
+  font-weight: 400;
+  font-style: normal;
+}
+
+@font-face {
+  font-family: 'AnotherFont';
+  // If you don't want to rename the font file itself, just put it into a folder with that name.
+  // The pattern for font recognition is font.*\.svg$
+  src: url("../font/awesome.svg#awesome") format("svg");
+  font-weight: 400;
+  font-style: normal;
+}
+
+
+body {
+  // SVG files inside an img or image folder will be considered images: resolved and put into the images folder.
+  // The pattern for image recognition is im[a]?g.*\.svg$
+  background-image:url('../img/img.svg');
+}

--- a/test/fixtures/fake-app/resources/assets/sass/font-and-image.scss
+++ b/test/fixtures/fake-app/resources/assets/sass/font-and-image.scss
@@ -19,7 +19,7 @@
 
 
 body {
-  // SVG files inside an img or image folder will be considered images: resolved and put into the images folder.
-  // The pattern for image recognition is im[a]?g.*\.svg$
+  // SVG files with any other name or in any other location will be considered images:
+  // resolved and put into the images folder.
   background-image:url('../img/img.svg');
 }


### PR DESCRIPTION
Both, fonts and images may be .svg files.

Before this commit, laravel-mix would consider all *.svg files to be font files. When resolved (e.g. because it was referred to in a scss file), they would have been copied to the fonts directory.

Now, laravel-mix distinguishes between the two types by considering their names or paths:

* font recognition pattern: `font.*\.svg$` will resolve font.svg, font2.svg and font/awesome.svg
* image recognition pattern: `im[a]?g.*\.svg$` will resolve img/1.svg and img1.svg

Images will be resolved and copied into the `images` directory, fonts will be resolved and copied into the `fonts` directory.