### PR TITLE
Remove unused asset parameter

### DIFF
--- a/src/plugins/CustomTasksPlugin.js
+++ b/src/plugins/CustomTasksPlugin.js
@@ -47,10 +47,8 @@ class CustomTasksPlugin {
 
     /**
      * Minify the given asset file.
-     *
-     * @param {File} asset
      */
-    minifyAssets(asset) {
+    minifyAssets() {
         let tasks = Mix.tasks.filter(task => task.constructor.name !== 'VersionFilesTask');
 
         tasks.forEach(task => {


### PR DESCRIPTION
I assume this is a remainder of an old implementation, but the `asset` parameter is unused here.