### PR TITLE
Add dependency verification when using globalVueStyles option

### DIFF
--- a/src/builder/webpack-rules.js
+++ b/src/builder/webpack-rules.js
@@ -1,5 +1,6 @@
 let webpack = require('webpack');
 let ExtractTextPlugin = require('extract-text-webpack-plugin');
+let Verify = require('../Verify');
 
 module.exports = function () {
     let rules = [];
@@ -265,6 +266,7 @@ module.exports = function () {
     // If we want to import a global styles file in every component,
     // use sass resources loader
     if (Config.extractVueStyles && Config.globalVueStyles) {
+	Verify.dependency('sass-resources-loader', ['sass-resources-loader']);
         tap(rules[rules.length - 1].options.loaders, vueLoaders => {
             vueLoaders.scss.push({
                 loader: 'sass-resources-loader',


### PR DESCRIPTION
Some time ago this PR was merged: https://github.com/JeffreyWay/laravel-mix/pull/1163. I recently found (watching Laracasts mix series!) of this functionality to install missing dependencies, so I think this should be included here as well.