### PR TITLE
Exclude non-essential files

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,9 +1,0 @@
-docs/
-test/
-.github/
-.nyc_output
-.idea
-coverage
-mix.sublime-project
-mix.sublime-workspace
-notes.md

--- a/package.json
+++ b/package.json
@@ -27,6 +27,11 @@
   ],
   "author": "Jeffrey Way",
   "license": "MIT",
+  "files": [
+    "icons",
+    "setup",
+    "src"
+  ],
   "dependencies": {
     "autoprefixer": "^7.1.1",
     "babel-core": "^6.24.1",


### PR DESCRIPTION
Switched from using `.npmignore` to the [`files`](https://docs.npmjs.com/files/package.json#files) array in package.json. This results in fewer lines, one less file and we don't need to keep track of which files to exclude.
  