### PR TITLE
Improve folder handling

### DIFF
--- a/src/Api.js
+++ b/src/Api.js
@@ -201,20 +201,33 @@ class Api {
      * @param {string|Array} src
      * @param {string}       output
      * @param {Boolean}      babel
+     * @param {Boolean}      deep
      */
-    combine(src, output = '', babel = false) {
+    combine(src, output = '', babel = false, deep = false) {
         output = new File(output);
+        src = [].concat(src);
 
         Verify.combine(src, output);
 
-        if (typeof src === 'string' && File.find(src).isDirectory()) {
-            src = _.pull(
-                glob.sync(path.join(src, '**/*'), { nodir: true }),
-                output.relativePath()
-            );
-        }
+        let files = [];
 
-        let task = new ConcatFilesTask({ src, output, babel });
+        src.forEach(f => {
+            f = File.find(f).isDirectory() ? path.join(f, deep ? '**/*' : '*') : f;
+
+            if (_.endsWith(f, '/*')) {
+                files = files.concat(glob.sync(f, { nodir: true }));
+            } else {
+                files.push(f);
+            }
+        });
+
+        files = _.pull(files, output.relativePath());
+
+        let task = new ConcatFilesTask({
+            src: files,
+            output,
+            babel
+        });
 
         Mix.addTask(task);
 
@@ -227,9 +240,10 @@ class Api {
      *
      * @param {string|Array} src
      * @param {string}       output
+     * @param {Boolean}      deep
      */
-    scripts(src, output) {
-        return this.combine(src, output);
+    scripts(src, output, deep = false) {
+        return this.combine(src, output, false, deep);
     };
 
 
@@ -238,11 +252,10 @@ class Api {
      *
      * @param {string|Array} src
      * @param {string}       output
+     * @param {Boolean}      deep
      */
-    babel(src, output) {
-        return this.combine(src, output, true);
-
-        return this;
+    babel(src, output, deep = false) {
+        return this.combine(src, output, true, deep);
     };
 
 
@@ -251,9 +264,10 @@ class Api {
      *
      * @param {string|Array} src
      * @param {string}       output
+     * @param {Boolean}      deep
      */
-    styles(src, output) {
-        return this.combine(src, output);
+    styles(src, output, deep = false) {
+        return this.combine(src, output, false, deep);
     };
 
 

--- a/test/features/mix.js
+++ b/test/features/mix.js
@@ -127,6 +127,72 @@ test.cb.serial('it combines a folder of scripts', t => {
 });
 
 
+test.cb.serial('it combines a deep folder of scripts', t => {
+    let output = 'test/fixtures/fake-app/public/all.js';
+
+    mix.scripts('test/fixtures/fake-app/resources/assets/js', output, true);
+
+    compile(t, () => {
+        t.true(File.exists(output));
+
+        t.is(
+            "alert('another stub');\n\nalert('stub');\n\nalert('another nested stub');\n",
+            File.find(output).read()
+        );
+    });
+});
+
+
+test.cb.serial('it combines a folder of files', t => {
+    let output = 'test/fixtures/fake-app/public/all.js';
+
+    mix.combine(['test/fixtures/fake-app/resources/assets/js'], output);
+
+    compile(t, () => {
+        t.true(File.exists(output));
+
+        t.is(
+            "alert('another stub');\n\nalert('stub');\n",
+            File.find(output).read()
+        );
+    });
+});
+
+
+test.cb.serial('it combines a deep folder of files', t => {
+    let output = 'test/fixtures/fake-app/public/all.js';
+
+    mix.combine(['test/fixtures/fake-app/resources/assets/js'], output, false, true);
+
+    compile(t, () => {
+        t.true(File.exists(output));
+
+        t.is(
+            "alert('another stub');\n\nalert('stub');\n\nalert('another nested stub');\n",
+            File.find(output).read()
+        );
+    });
+});
+
+
+test.cb.serial('it combines a deep folder of files (with asterisk)', t => {
+    let output = 'test/fixtures/fake-app/public/all.js';
+
+    mix.combine('test/fixtures/fake-app/resources/assets/js/**/*', output);
+
+    compile(t, () => {
+        console.log(File.find(output).read());
+
+        t.true(File.exists(output));
+
+        t.is(
+            "alert('another stub');\n\nalert('stub');\n\nalert('another nested stub');\n",
+            File.find(output).read()
+        );
+    });
+});
+
+
 test.cb.serial('it can minify a file', t => {
     mix.js('test/fixtures/fake-app/resources/assets/js/app.js', 'js')
        .minify('test/fixtures/fake-app/public/js/app.js');

--- a/test/fixtures/fake-app/resources/assets/js/nested/another.js
+++ b/test/fixtures/fake-app/resources/assets/js/nested/another.js
@@ -1,0 +1,1 @@
+alert('another nested stub');


### PR DESCRIPTION
Right now, if we have something like this, It would be fail.

```
mix.combine([
    'resources/assets/js/app.js',
    'resources/assets/js/custom',
], 'public/js/app.js');
```

```
mix.combine('resources/assets/js/*', 'public/js/app.js');
```

```
mix.combine([
    'resources/assets/js/app.js',
    'resources/assets/js/custom/**/*'
], 'public/js/app.js');
```

With this PR, the above cases would be succeeded. And we don't force user to combine the nested folder. If they would need to combine nested folder, they can use asterisk `**/*` or by setting the `deep` param to `true`.

```
mix.combine('resources/assets/js', 'public/js/app.js', false, true);
```
```
mix.scripts('resources/assets/js', 'public/js/app.js', true);
```
```
mix.styles('resources/assets/css', 'public/css/app.css', true);
```
  