### PR TITLE
Allow multiple webpackConfig calls

### DIFF
--- a/src/Api.js
+++ b/src/Api.js
@@ -459,7 +459,11 @@ class Api {
      * @param {object} config
      */
     webpackConfig(config) {
-        Config.webpackConfig = (typeof config == 'function') ? config(webpack) : config;
+        config = (typeof config == 'function') ? config(webpack) : config;
+
+        Config.webpackConfig = require('webpack-merge').smart(
+            Config.webpackConfig, config
+        );
 
         return this;
     }


### PR DESCRIPTION
For example

```
mix.webpackConfig({ ... })
   .webpackConfig({ ... });
```

Not useful in that example, but I'm trying to add functionality to mix in an external file. If I use `webpackConfig` there, it will break if it gets overridden.