### PR TITLE
Editing Manifest normalizePath method to escape Config.publicPath special characters

### DIFF
--- a/src/Manifest.js
+++ b/src/Manifest.js
@@ -121,9 +121,10 @@ class Manifest {
      * @param {string} filePath
      */
     normalizePath(filePath) {
-        filePath = filePath.replace(
-            new RegExp('^' +  Config.publicPath), ''
-        ).replace(/\\/g, '/');
+        if (Config.publicPath && filePath.startsWith(Config.publicPath)) {
+            filePath = filePath.substring(Config.publicPath.length);
+        }
+        filePath = filePath.replace(/\\/g, '/');
 
         if (! filePath.startsWith('/')) {
             filePath = '/' + filePath;


### PR DESCRIPTION
when I tried to set public path to root, every thing was okay. but I got error on version when running:
`npm run prod`

**Steps To Reproduce:**

webpack.mix.js
```
mix.setPublicPath('./');
mix.sass("Resources/sass/uikit/theme.scss", "content/css/uikit.css")
    .version();
```

Resulting manifest.json:
```
{
    "/ontent/css/uikit.css": "/ontent/css/uikit.css?id=ff7f39e6c3f32433eaee"
}
```
npm run prod
```
fs.js:642
  return binding.open(pathModule._makeLong(path), stringToFlags(flags), mode);
                 ^

Error: ENOENT: no such file or directory, open 'G:\git_projects\mobile-shop\MobileShop\ontent\css\uikit.css'

```

**Related issues** [#1373](https://github.com/JeffreyWay/laravel-mix/issues/1373) [1326](https://github.com/JeffreyWay/laravel-mix/issues/1326)

but after debugging the code the problem was in manifest.js normalizePath and escaping special characters in Config.publicPath magically solved the issue.