### PR TITLE
Add none-specific options to vue-loader

### DIFF
--- a/src/builder/webpack-rules.js
+++ b/src/builder/webpack-rules.js
@@ -252,7 +252,8 @@ module.exports = function () {
             postcss: Config.postCss,
             preLoaders: Config.vue.preLoaders,
             postLoaders: Config.vue.postLoaders,
-            esModule: Config.vue.esModule
+            esModule: Config.vue.esModule,
+            ...Config.vue.options
         }
     });
 

--- a/src/config.js
+++ b/src/config.js
@@ -169,7 +169,8 @@ module.exports = function () {
         vue: {
             preLoaders: {},
             postLoaders: {},
-            esModule: false
+            esModule: false,
+            options: {}
         },
 
 


### PR DESCRIPTION
This is mainly meant as a discussion first, the idea is simple but not sure how well it will hold up overall and would love to hear thoughts (even if I completely missed a resource on how to do this without this edit).

I personally ran into an issue of trying to figure out how to adjust vue-loaders config for cssModules. I could not find any resources on how to do it in the context of mix, so this is my solution to adding a way to do it directly to mix, while also supporting any other adjustment needed to vue-loader.

I added an `options` key to the vue config that adds all options within to the vue-loader options.

Like so:
```
config.vue.options.cssModules = {
    localIdentName: '[local]---[hash:base64:5]',
    camelCase: true
}
```
This will add the `cssModules` key directly into the loader, without needing to overwrite mix's default settings. It also supports any other additional configuration that might be needed. Although mix covers basically everything else this will future proof the config.

This also opens up all the options to run through `config.vue.options` (including loaders). and have all the rules built on it. It will allow much more control over vue-loader by mix (and removes the need to use object spread / merging to pull it in).

Sort of opinionated but works for my use case, would love to see thoughts on the idea and if I should do any additional adjustments.