### PR TITLE
Find approach sometimes deletes the wrong file

### DIFF
--- a/src/plugins/MockEntryPlugin.js
+++ b/src/plugins/MockEntryPlugin.js
@@ -13,7 +13,7 @@ class MockEntryPlugin {
         compiler.plugin('done', stats => {
             let temporaryOutputFile = stats.toJson()
                 .assets
-                .find(asset => asset.chunkNames.includes('mix'));
+                .find(asset => asset.name.includes('mix.js'));
 
             if (temporaryOutputFile) {
                 delete stats.compilation.assets[temporaryOutputFile.name];


### PR DESCRIPTION
Discovered a weird bug where compiling > 9 .less files was always produced .css file short.
Traced it down to this function where it was deleting a compiled .css file instead of the intended `mix.js`.
Full details here: https://github.com/JeffreyWay/laravel-mix/issues/1420