### PR TITLE
can't change sourceMap type when production

### DIFF
--- a/src/Api.js
+++ b/src/Api.js
@@ -375,9 +375,15 @@ class Api {
      * @param {Boolean} productionToo
      * @param {string}  type
      */
-    sourceMaps(productionToo = true, type = 'eval-source-map') {
+    sourceMaps(productionToo = true, type) {
         if (Mix.inProduction()) {
-            type = productionToo ? 'source-map' : false;
+            type = type || 'source-map';
+        } else {
+            type = type || 'eval-source-map';
+        }
+        
+        if (!productionToo) {
+            type = false;
         }
 
         Config.sourcemaps = type;


### PR DESCRIPTION
Sometimes, I use `mix.sourceMaps(true, 'hidden-source-map');` can't useful.

when production, I can't customize the type of sourceMap.

I commit the PR，want to solve this problem.