### PR TITLE
Fix bug: extractVueStyles not using specified file

### DIFF
--- a/src/builder/webpack-rules.js
+++ b/src/builder/webpack-rules.js
@@ -232,9 +232,8 @@ module.exports = function() {
     });
 
     // Vue Compilation.
-    let vueExtractPlugin;
-
     if (Config.extractVueStyles) {
+
         let fileName =
             typeof Config.extractVueStyles === 'string'
                 ? Config.extractVueStyles
@@ -242,10 +241,11 @@ module.exports = function() {
         let filePath = fileName
             .replace(Config.publicPath, '')
             .replace(/^\//, '');
-        vueExtractPlugin = extractPlugins.length
-            ? extractPlugins[0]
-            : new ExtractTextPlugin(filePath);
+        extractPlugins.push(new ExtractTextPlugin(filePath));
     }
+
+    // either use the common extract plugin or the vue extract plugin, if extractVueStyles has been specified
+    const extractPlugin = extractPlugins[extractPlugins.length-1];
 
     rules.push({
         test: /\.vue$/,
@@ -261,28 +261,28 @@ module.exports = function() {
                               options: Config.babel()
                           },
 
-                          scss: vueExtractPlugin.extract({
+                          scss: extractPlugin.extract({
                               use: 'css-loader!sass-loader',
                               fallback: 'vue-style-loader'
                           }),
 
-                          sass: vueExtractPlugin.extract({
+                          sass: extractPlugin.extract({
                               use: 'css-loader!sass-loader?indentedSyntax',
                               fallback: 'vue-style-loader'
                           }),
 
-                          css: vueExtractPlugin.extract({
+                          css: extractPlugin.extract({
                               use: 'css-loader',
                               fallback: 'vue-style-loader'
                           }),
 
-                          stylus: vueExtractPlugin.extract({
+                          stylus: extractPlugin.extract({
                               use:
                                   'css-loader!stylus-loader?paths[]=node_modules',
                               fallback: 'vue-style-loader'
                           }),
 
-                          less: vueExtractPlugin.extract({
+                          less: extractPlugin.extract({
                               use: 'css-loader!less-loader',
                               fallback: 'vue-style-loader'
                           })
@@ -298,12 +298,6 @@ module.exports = function() {
             Config.vue
         )
     });
-
-    // If there were no existing extract text plugins to add our
-    // Vue styles extraction too, we'll push a new one in.
-    if (Config.extractVueStyles && !extractPlugins.length) {
-        extractPlugins.push(vueExtractPlugin);
-    }
 
     // If we want to import a global styles file in every component,
     // use sass resources loader

--- a/test/features/mix.js
+++ b/test/features/mix.js
@@ -211,6 +211,24 @@ test.cb.serial('it resolves image- and font-urls and distinguishes between them 
     });
 });
 
+test.cb('it extracts vue styles correctly', t => {
+    // Given we have a js file that imports vue
+    mix.js('test/fixtures/fake-app/resources/assets/vue/app-with-vue.js', 'js/app.js')
+        // And a scss file with some styles
+        .sass('test/fixtures/fake-app/resources/assets/sass/app.scss', 'css/app.css')
+        // and we want to extract vue styles
+        .options({extractVueStyles: 'css/components.css'});
+    // When we compile it
+    compile(t, () => {
+        // Then we expect the js to be built
+        t.true(File.exists('test/fixtures/fake-app/public/js/app.js'));
+        // And the app.css to be built
+        t.true(File.exists('test/fixtures/fake-app/public/css/app.css'));
+        // And the extracted vue styles to be in their own css
+        t.true(File.exists('test/fixtures/fake-app/public/css/components.css'));
+    })
+
+});
 
 function compile(t, callback) {
     let config = new WebpackConfig().build();

--- a/test/fixtures/fake-app/resources/assets/vue/Basic.vue
+++ b/test/fixtures/fake-app/resources/assets/vue/Basic.vue
@@ -1,0 +1,19 @@
+<template>
+    <div class="hello">{{ message }}</div>
+</template>
+
+<script>
+    module.exports = {
+        data() {
+            return {
+                message: 'Hello World',
+            }
+        }
+    }
+</script>
+
+<style lang="scss">
+    .hello {
+        color: blue;
+    }
+</style>

--- a/test/fixtures/fake-app/resources/assets/vue/app-with-vue.js
+++ b/test/fixtures/fake-app/resources/assets/vue/app-with-vue.js
@@ -1,0 +1,8 @@
+import 'vue';
+import Basic from './Basic.vue';
+
+new Vue({
+    components: {
+        Basic,
+    }
+}).$mount('#app');


### PR DESCRIPTION
Fixes #1460

Before the fix, we would recycle an existing extract plugin without assigning the custom extraction filename.
This is now fixed.

Please note that PR #1466 needs to be updated after merging this PR, because it extracted the rules into dedicated files and I doubt that git is smart enough to merge these changes.