### PR TITLE
Work In Progress: Opt-in filename based versioning

### DIFF
--- a/src/Manifest.js
+++ b/src/Manifest.js
@@ -49,11 +49,20 @@ class Manifest {
      * @param {string} file
      */
     hash(file) {
-        let hash = new File(path.join(Config.publicPath, file)).version();
+        let f = new File(path.join(Config.publicPath, file));
+        let hash = f.version();
 
-        let filePath = this.normalizePath(file);
+        if (Config.versionInFilename) {
+            let filePathParts = path.parse(file)
+            let newFileName = filePathParts.name + '.' + hash + filePathParts.ext
 
-        this.manifest[filePath] = filePath + '?id=' + hash;
+            f.rename(newFileName);
+
+            this.manifest[file] = path.join(filePathParts.dir, newFileName);
+        } else {
+            this.manifest[file] = file + '?id=' + hash;
+        }
+
 
         return this;
     }

--- a/src/config.js
+++ b/src/config.js
@@ -135,6 +135,7 @@ module.exports = function() {
          */
         versioning: false,
 
+        versionInFilename: false,
         /**
          * Determine if error notifications should be displayed for each build.
          *


### PR DESCRIPTION
Initial concept for re-introducing filename versioning for cache busting. 

I am not completely comfortable with where certain things are implemented. I think I'd like to see the logic for version hashing + renaming of files in the `CustomTasksPlugin.applyVersioning()` instead of inside the Manifest itself.

@JeffreyWay the one question I have from you is: how should people opt-into this? Currently, it can be triggered by putting `Config.versionInFilename = true;` in the webpack.mix.js file.  Thoughts on that?

EDIT:

In the mean time, **adding this plugin** should provide the needed support: 
https://www.npmjs.com/package/laravel-mix-filename-versioning

code at:
https://github.com/ralphschindler/laravel-mix-filename-versioning