### PR TITLE
Rollback vue-loader to v13

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5458,13 +5458,6 @@
             }
           }
         },
-        "string_decoder": {
-          "version": "1.0.1",
-          "bundled": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
-          }
-        },
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
@@ -5472,6 +5465,13 @@
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
             "strip-ansi": "3.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
           }
         },
         "stringstream": {
@@ -12565,9 +12565,9 @@
       "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks="
     },
     "prettier": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.10.2.tgz",
-      "integrity": "sha512-TcdNoQIWFoHblurqqU6d1ysopjq7UX0oRcT/hJ8qvBAELiYWn+Ugf0AXdnzISEJ7vuhNnQ98N8jR8Sh53x4IZg=="
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.11.1.tgz",
+      "integrity": "sha512-T/KD65Ot0PB97xTrG8afQ46x3oiVhnfGjGESSI9NWYcG92+OUPZKkwHqGWXH2t9jK1crnQjubECW0FuOth+hxw=="
     },
     "pretty-format": {
       "version": "19.0.0",
@@ -14205,14 +14205,6 @@
       "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
       "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM="
     },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
     "string-length": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-1.0.1.tgz",
@@ -14229,6 +14221,14 @@
         "code-point-at": "1.1.0",
         "is-fullwidth-code-point": "1.0.0",
         "strip-ansi": "3.0.1"
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "requires": {
+        "safe-buffer": "5.1.1"
       }
     },
     "stringstream": {
@@ -15505,14 +15505,14 @@
       "dev": true
     },
     "vue-hot-reload-api": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/vue-hot-reload-api/-/vue-hot-reload-api-2.2.4.tgz",
-      "integrity": "sha512-e+ThJMYmZg4D9UnrLcr6LQxGu6YlcxkrmZGPCyIN4malcNhdeGGKxmFuM5y6ICMJJxQywLfT8MM1rYZr4LpeLw=="
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/vue-hot-reload-api/-/vue-hot-reload-api-2.3.0.tgz",
+      "integrity": "sha512-2j/t+wIbyVMP5NvctQoSUvLkYKoWAAk2QlQiilrM2a6/ulzFgdcLUJfTvs4XQ/3eZhHiBmmEojbjmM4AzZj8JA=="
     },
     "vue-loader": {
-      "version": "14.1.1",
-      "resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-14.1.1.tgz",
-      "integrity": "sha512-ZLu0yWohbWPayFhSPy80xnObCrPDLGrf/v9R5kJyUbVlcI46srnQlaG+HnTN5HAt5nV9iJiF4oJIjX0+jK+f0w==",
+      "version": "13.7.1",
+      "resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-13.7.1.tgz",
+      "integrity": "sha512-v6PbKMGl/hWHGPxB2uGHsA66vusrXF66J/h1QiFXtU6z5zVSK8jq5xl95M1p3QNXmuEJKNP3nxoXfbgQNs7hJg==",
       "requires": {
         "consolidate": "0.14.5",
         "hash-sum": "1.0.2",
@@ -15521,18 +15521,18 @@
         "postcss": "6.0.14",
         "postcss-load-config": "1.2.0",
         "postcss-selector-parser": "2.2.3",
-        "prettier": "1.10.2",
+        "prettier": "1.11.1",
         "resolve": "1.5.0",
         "source-map": "0.6.1",
-        "vue-hot-reload-api": "2.2.4",
-        "vue-style-loader": "4.0.2",
+        "vue-hot-reload-api": "2.3.0",
+        "vue-style-loader": "3.1.2",
         "vue-template-es2015-compiler": "1.6.0"
       },
       "dependencies": {
         "vue-style-loader": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/vue-style-loader/-/vue-style-loader-4.0.2.tgz",
-          "integrity": "sha512-Bwf1Gf331Z5OTzMRAYQYiFpFbaCpaXQjQcSvWYsmEwSgOIVa+moXWoD8fQCNetcekbP3OSE5pyvomNKbvIUQtQ==",
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/vue-style-loader/-/vue-style-loader-3.1.2.tgz",
+          "integrity": "sha512-ICtVdK/p+qXWpdSs2alWtsXt9YnDoYjQe0w5616j9+/EhjoxZkbun34uWgsMFnC1MhrMMwaWiImz3K2jK1Yp2Q==",
           "requires": {
             "hash-sum": "1.0.2",
             "loader-utils": "1.1.0"
@@ -15544,6 +15544,7 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/vue-style-loader/-/vue-style-loader-4.0.2.tgz",
       "integrity": "sha512-Bwf1Gf331Z5OTzMRAYQYiFpFbaCpaXQjQcSvWYsmEwSgOIVa+moXWoD8fQCNetcekbP3OSE5pyvomNKbvIUQtQ==",
+      "dev": true,
       "requires": {
         "hash-sum": "1.0.2",
         "loader-utils": "1.1.0"

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "style-loader": "^0.18.2",
     "uglify-js": "^2.8.29",
     "uglifyjs-webpack-plugin": "^1.1.8",
-    "vue-loader": "^14.1.1",
+    "vue-loader": "^13.7.1",
     "vue-template-compiler": "^2.5.13",
     "webpack": "^3.11.0",
     "webpack-chunk-hash": "^0.4.0",


### PR DESCRIPTION
Laravel mix v2.0.0 was using vue-loader v13.x while v2.1 is using v14.x.
Since vue-loader v14 has a breaking change so lets rollback the version to v13.

https://github.com/vuejs/vue-loader/releases/tag/v14.0.0

Steps taken:
```
npm install
npm uninstall vue-loader
npm install vue-loader@^13
```

Fixes https://github.com/JeffreyWay/laravel-mix/issues/1524
