### PR TITLE
Fix adding of vue webpack rules when using TypeScript component

### DIFF
--- a/src/components/TypeScript.js
+++ b/src/components/TypeScript.js
@@ -35,6 +35,8 @@ class TypeScript extends JavaScript {
      * @param {Object} config
      */
     webpackConfig(config) {
+        super.webpackConfig(config)
+
         config.resolve.extensions.push('.ts', '.tsx');
         config.resolve.alias['vue$'] = 'vue/dist/vue.esm.js';
     }

--- a/test/features/vue.js
+++ b/test/features/vue.js
@@ -122,3 +122,13 @@ test.cb.serial('it extracts vue styles to a dedicated file', t => {
         );
     });
 });
+
+test.serial('it does also add the vue webpack rules with typescript component', t => {
+    mix.ts('resources/assets/js/app.js', 'public/js');
+
+    t.truthy(
+        buildConfig().module.rules.find(
+            rule => rule.test.toString() === '/\\.vue$/'
+        )
+    );
+});


### PR DESCRIPTION
When using only `.ts()` component but never `.js()` the vue rules where not added as the TypeScript component overwrites the `webpackConfig` method of the JavaScript component and never calls the parent/super method.

This PR adds a super call to fix this issue.