### PR TITLE
Don't cut filePath if the publicPath is '.' (root)

### DIFF
--- a/src/Manifest.js
+++ b/src/Manifest.js
@@ -120,7 +120,7 @@ class Manifest {
      * @param {string} filePath
      */
     normalizePath(filePath) {
-        if (Config.publicPath && filePath.startsWith(Config.publicPath)) {
+        if (Config.publicPath && filePath.startsWith(Config.publicPath) && Config.publicPath.startsWith !== '.') {
             filePath = filePath.substring(Config.publicPath.length);
         }
         filePath = filePath.replace(/\\/g, '/');


### PR DESCRIPTION
That allows for people to use `.nicefolder/example.css`  as a `filePath`. Without it, if the user sets the public folder as root ('.'), the `filePath` will be cutted by one, leaving the manifest with paths like '/ublic/styles/main.css`.