### PR TITLE
Output webpack chunks in public/js/

### DIFF
--- a/src/builder/WebpackConfig.js
+++ b/src/builder/WebpackConfig.js
@@ -62,7 +62,7 @@ class WebpackConfig {
         this.webpackConfig.output = {
             path: path.resolve(Mix.isUsing('hmr') ? '/' : Config.publicPath),
             filename: '[name].js',
-            chunkFilename: '[name].js',
+            chunkFilename: 'js/[name].chunk.js',
             publicPath: Mix.isUsing('hmr')
                 ? http +
                   '://' +


### PR DESCRIPTION
The current default behavior of laravel-mix when handling code splitting is that it drops the output chunks directly into the public folder. (`public/0.js`)

This modifies the config to place chunks into the js folder with this filename format: (`public/js/0.chunk.js`).