### PR TITLE
Let the lazy-load chunk have hash for versioning

### DIFF
--- a/src/builder/WebpackConfig.js
+++ b/src/builder/WebpackConfig.js
@@ -62,7 +62,7 @@ class WebpackConfig {
         this.webpackConfig.output = {
             path: path.resolve(Mix.isUsing('hmr') ? '/' : Config.publicPath),
             filename: '[name].js',
-            chunkFilename: '[name].js',
+            chunkFilename: Mix.components.get('version') ? '[name].[hash].js' : '[name].js',
             publicPath: Mix.isUsing('hmr')
                 ? http +
                   '://' +


### PR DESCRIPTION
Otherwise, chunks for lazy-loading never get hashed, so it defeats the purpose of have versioning.