### PR TITLE
Make webpack built notifications transient on linux

### DIFF
--- a/src/components/Notifications.js
+++ b/src/components/Notifications.js
@@ -11,6 +11,7 @@ class Notifications extends AutomaticComponent {
             return new WebpackNotifierPlugin({
                 title: 'Laravel Mix',
                 alwaysNotify: Config.notifications.onSuccess,
+                hint: process.platform === 'linux' ? 'int:transient:1' : undefined,
                 contentImage: Mix.paths.root(
                     'node_modules/laravel-mix/icons/laravel.png'
                 )


### PR DESCRIPTION
Currently if you are rebuilding often your notification panel gets flooded with notifications forcing you to either "clear all" or clear the 200 odd "Build Successful" notifications.

This patch marks the notifications as transient on linux meaning they are never saved to the notification center and simply disappear into the abyss after being displayed.