### PR TITLE
Disable CSS & JS minification by default and allow minify() in development

### DIFF
--- a/docs/concatenation-and-minification.md
+++ b/docs/concatenation-and-minification.md
@@ -39,7 +39,12 @@ mix.minify(['this/one.js', 'and/this/one.js']);
 There are a few things worth noting here:
 
 1. This method will create a companion `*.min.ext` file. So minifying `app.js` will generate `app.min.js`.
-2. Once again, the minification will only take place during a production build. \(`export NODE_ENV=production`\).
+2. Minification can be slow and uneccessary for development. To keep devlopment quick check if it is a production build before caling `mix.minify()`. 
+```js
+if (mix.inProduction()) {
+    mix.minify('path/to/file.js');
+}
+```
 3. There is no need to call `mix.combine(['one.js', 'two.js'], 'merged.js').minify('merged.js');`Just stick with the single `mix.combine()` call. It'll take care of both.
 
 > **Important**: Please note that minification is only available for CSS and JavaScript files. The minifier will not understand any other provided file type.

--- a/src/builder/webpack-plugins.js
+++ b/src/builder/webpack-plugins.js
@@ -43,7 +43,6 @@ module.exports = function() {
     // Add some general Webpack loader options.
     plugins.push(
         new webpack.LoaderOptionsPlugin({
-            minimize: true,
             options: {
                 context: __dirname,
                 output: { path: './' }

--- a/src/builder/webpack-plugins.js
+++ b/src/builder/webpack-plugins.js
@@ -43,19 +43,13 @@ module.exports = function() {
     // Add some general Webpack loader options.
     plugins.push(
         new webpack.LoaderOptionsPlugin({
-            minimize: Mix.inProduction(),
+            minimize: true,
             options: {
                 context: __dirname,
                 output: { path: './' }
             }
         })
     );
-
-    // If we're in production environment, with Uglification turned on, we'll
-    // clean up and minify all of the user's JS and CSS automatically.
-    if (Mix.inProduction() && Config.uglify) {
-        plugins.push(new UglifyJSPlugin(Config.uglify));
-    }
 
     // Handle all custom, non-webpack tasks.
     plugins.push(new ManifestPlugin());

--- a/src/components/Preprocessor.js
+++ b/src/components/Preprocessor.js
@@ -35,7 +35,8 @@ class Preprocessor {
                         options: {
                             url: Config.processCssUrls,
                             sourceMap: Mix.isUsing('sourcemaps'),
-                            importLoaders: 1
+                            importLoaders: 1,
+                            minimize: false
                         }
                     },
 

--- a/src/config.js
+++ b/src/config.js
@@ -159,7 +159,7 @@ module.exports = function() {
                                 modules: false,
                                 targets: {
                                     browsers: ['> 2%'],
-                                    uglify: true
+                                    uglify: false
                                 }
                             }
                         ]

--- a/src/webpackPlugins/CustomTasksPlugin.js
+++ b/src/webpackPlugins/CustomTasksPlugin.js
@@ -11,11 +11,7 @@ class CustomTasksPlugin {
             if (Mix.components.get('version')) {
                 this.applyVersioning();
             }
-
-            if (Mix.inProduction()) {
-                this.minifyAssets();
-            }
-
+            this.minifyAssets();
             if (Mix.isWatching()) {
                 Mix.tasks.forEach(task => task.watch(Mix.isPolling()));
             }


### PR DESCRIPTION
This pull request disables the automatic minification of CSS files by css-loader (css-nano) in development and production and removes automatic JS minification in production. Minification should only occur when calling `mix.minify()` or `mix.combine()` are called and matches the standard naming convention for minified versions of assets (`*.min.ext`)

The current setup is far too opinionated about minifying assets in production and offered no way to configure or disable cssnano. This is a real headache when debugging issues in minification such as https://stackoverflow.com/questions/49516072/wrong-output-on-npm-run-prod