### PR TITLE
Recognizes scoped package dependencies in mix extension - resolves #1577

### DIFF
--- a/src/Verify.js
+++ b/src/Verify.js
@@ -77,7 +77,7 @@ class Verify {
         list
             .reject(dependency => {
                 try {
-                    return require.resolve(dependency.replace(/@.+$/, ''));
+                    return require.resolve(dependency.replace(/(?!^@)@.+$/, ''));
                 } catch (e) {}
             })
             .tap(dependencies => {
@@ -96,7 +96,7 @@ class Verify {
         if (argv['$0'].includes('ava')) return;
 
         try {
-            require.resolve(name.replace(/@.+$/, ''));
+            require.resolve(name.replace(/(?!^@)@.+$/, ''));
         } catch (e) {
             installDependencies(name, abortOnComplete);
         }


### PR DESCRIPTION
Previous regex pattern replaces all characters after '@' symbol.
So package names like `@fortawesome/fontawesome` would be converted to an empty string.
Resulting in failure to detect the installed dependencies.

