### PR TITLE
Fix LiveReload Plugin Installation Instructions

### DIFF
--- a/docs/livereload.md
+++ b/docs/livereload.md
@@ -5,7 +5,7 @@ While Laravel Mix ships with Browsersync support out of the box, you may prefer 
 ## 1. Install webpack-livereload-plugin
 
 ```
-npm install webpack-livereload-plugin --save-dev
+npm install webpack-livereload-plugin@1 --save-dev
 ```
 
 ## 2. Configure `webpack.mix.js`


### PR DESCRIPTION
With the launch of Webpack 4, it is necessary to inform the version of the plugin to be installed, in order to avoid problems in the construction of the assets.

references:
https://github.com/statianzo/webpack-livereload-plugin#installation