### PR TITLE
add blank line at end of files written

### DIFF
--- a/src/File.js
+++ b/src/File.js
@@ -1,3 +1,4 @@
+let os = require("os");
 let md5 = require('md5');
 let path = require('path');
 let fs = require('fs-extra');
@@ -150,6 +151,8 @@ class File {
         if (typeof body === 'object') {
             body = JSON.stringify(body, null, 4);
         }
+        
+        body = body + os.EOL;
 
         fs.writeFileSync(this.absolutePath, body);
 


### PR DESCRIPTION
Add blank line at the end of files emitted to appease version control.

This is aimed at `git` and the generated `mix-manifest.json` file.