### PR TITLE
Removed repeated snippet

### DIFF
--- a/docs/autoloading.md
+++ b/docs/autoloading.md
@@ -1,11 +1,5 @@
 # Autoloading
 
-```js
-mix.autoload({
-   jquery: ['$', 'window.jQuery']
-});
-```
-
 Webpack offers the necessary facilities to make a module available as a variable in every other module required by webpack. If you're working with a particular plugin or library that depends upon a global variable, such as jQuery, `mix.autoload()` may prove useful to you.
 
 Consider the following example:


### PR DESCRIPTION
The example of mix.autoload() was showing twice. I think it isn't necessary.