### PR TITLE
Support port number from CLI

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -45,13 +45,14 @@ if (Mix.sees('laravel')) {
 Mix.listen('init', () => {
     if (Mix.shouldHotReload()) {
         let http = process.argv.includes('--https') ? 'https' : 'http';
+        let port = process.argv.includes('--port') ? process.argv[process.argv.indexOf('--port') + 1] : Config.hmrOptions.port;
 
         new File(path.join(Config.publicPath, 'hot')).write(
             http +
                 '://' +
                 Config.hmrOptions.host +
                 ':' +
-                Config.hmrOptions.port +
+                port +
                 '/'
         );
     }


### PR DESCRIPTION
If I run `npm run hot -- --port=1235`, the the `public/hot` file is still `http://localhost:8080`

This PR fixes this so the url in `public/hot` is `http://localhost:1235`