### PR TITLE
Don't try to minify code in CopyFilesTask tasks

### DIFF
--- a/src/webpackPlugins/CustomTasksPlugin.js
+++ b/src/webpackPlugins/CustomTasksPlugin.js
@@ -47,9 +47,9 @@ class CustomTasksPlugin {
      * Minify the given asset file.
      */
     minifyAssets() {
-        let tasks = Mix.tasks.filter(
-            task => task.constructor.name !== 'VersionFilesTask'
-        );
+        let tasks = Mix.tasks.filter(task => {
+            return task.constructor.name !== 'VersionFilesTask' && task.constructor.name !== 'CopyFilesTask';
+        });
 
         tasks.forEach(task => {
             task.assets.forEach(asset => {


### PR DESCRIPTION
Fixes #1666. Two things:

1. I'm pretty sure `mix.copy()` was intended to simply move files while leaving their contents untouched. But correct me if I'm wrong.
2. I don't know how to write a test for this.