### PR TITLE
Allow autoloading of module properties

### DIFF
--- a/src/components/Autoload.js
+++ b/src/components/Autoload.js
@@ -10,7 +10,7 @@ class Autoload {
 
         Object.keys(libs).forEach(library => {
             [].concat(libs[library]).forEach(alias => {
-                aliases[alias] = library;
+                aliases[alias] = library.includes('.') ? library.split('.') : library;
             });
         });
 

--- a/test/features/autoload.js
+++ b/test/features/autoload.js
@@ -2,7 +2,8 @@ import mix from './helpers/setup';
 
 test.cb.serial('it handles library autoloading', t => {
     mix.autoload({
-        jquery: ['$', 'window.jQuery']
+        jquery: ['$', 'window.jQuery'],
+        'lodash.map': '_map',
     });
 
     compile(t, config => {
@@ -13,7 +14,8 @@ test.cb.serial('it handles library autoloading', t => {
         t.deepEqual(
             {
                 $: 'jquery',
-                'window.jQuery': 'jquery'
+                'window.jQuery': 'jquery',
+                '_map': ['lodash', 'map']
             },
             providePlugin.definitions
         );


### PR DESCRIPTION
This PR allows the autoloading of module properties as shown in the [ProvidePlugin docs](https://webpack.js.org/plugins/provide-plugin/#usage-lodash-map)

It adds support the following syntax in the autoload method:

```js
mix.autoload({
    'lodash.map': '_map'
});
```

Which would then allow you in your source code to do this:

```js
_map([1, 2, 3), () => {});
```

It would be the equivalent of doing:

```js
let { map } = require('lodash');

map([1, 2, 3], () => {});
```
