### PR TITLE
Add inDevelopment method

### DIFF
--- a/src/Api.js
+++ b/src/Api.js
@@ -95,6 +95,13 @@ class Api {
     inProduction() {
         return Mix.inProduction();
     }
+
+    /**
+     * Helper for determining a development environment.
+     */
+    inDevelopment() {
+        return Mix.inDevelopment();
+    }
 }
 
 module.exports = Api;

--- a/src/Mix.js
+++ b/src/Mix.js
@@ -34,6 +34,13 @@ class Mix {
     }
 
     /**
+     * Determine if Mix is executing in a development environment.
+     */
+    inDevelopment() {
+        return Config.development;
+    }
+
+    /**
      * Determine if Mix should watch files for changes.
      */
     isWatching() {

--- a/src/StandaloneSass.js
+++ b/src/StandaloneSass.js
@@ -72,7 +72,7 @@ class StandaloneSass {
             sassOptions.push('--importer ' + this.pluginOptions.importer);
         }
 
-        if (Mix.isUsing('sourcemaps') && !Mix.inProduction()) {
+        if (Mix.isUsing('sourcemaps') && Mix.inDevelopment()) {
             sassOptions.push('--source-map-embed');
         }
 

--- a/test/mix.js
+++ b/test/mix.js
@@ -14,6 +14,12 @@ test('that it knows if it is being executed in a production environment', t => {
     t.true(Mix.inProduction());
 });
 
+test('that it knows if it is being executed in a development environment', t => {
+    Config.development = true;
+
+    t.true(Mix.inDevelopment());
+});
+
 test('that it can check if a certain config item is truthy', t => {
     Config.versioning = true;
 


### PR DESCRIPTION
This method comes in handy when you want to check if you're working in a development environment. As production and development are the most common environments to work in, often more names like staging, testing, etc. are used to denounce specific environments. Having a specific helper to indicate the development environment can come in handy when running certain processes which are only necessary for development.