### PR TITLE
Add a sample command to make src/app.js and src/app.scss

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -45,7 +45,7 @@ mix.js('src/app.js', 'dist')
    .setPublicPath('dist');
 ```
 
-Take note of the source paths, and create the directory structure to match \(or, of course, change them to your preferred structure\). You're all set now. Compile everything down by running `node_modules/.bin/webpack` from the command line. You should now see:
+Take note of the source paths. You're free to amend the paths to match your preferred structure, but if you're happy with our defaults simply run `mkdir src && touch src/app.{js,scss}` to create the files/directories. You're all set now. Compile everything down by running `node_modules/.bin/webpack` from the command line. You should now see:
 
 * `dist/app.css`
 * `dist/app.js`


### PR DESCRIPTION
We're giving devs' a sample webpack.mix.js file, so I guess there's no harm in giving them a simple snippet to create the necessary file/directories.