### PR TITLE
Add mergeManifest option

### DIFF
--- a/setup/webpack.mix.js
+++ b/setup/webpack.mix.js
@@ -49,4 +49,5 @@ mix.js('src/app.js', 'dist/').sass('src/app.scss', 'dist/');
 //   purifyCss: false, // Remove unused CSS selectors.
 //   uglify: {}, // Uglify-specific options. https://webpack.github.io/docs/list-of-plugins.html#uglifyjsplugin
 //   postCss: [] // Post-CSS options: https://github.com/postcss/postcss/blob/master/docs/plugins.md
+//   mergeManifest: false // Merge the contents of the mix-manifest.json instead of rewriting the contents.
 // });

--- a/src/Manifest.js
+++ b/src/Manifest.js
@@ -79,6 +79,10 @@ class Manifest {
      * Refresh the mix-manifest.js file.
      */
     refresh() {
+        if (Config.mergeManifest) {
+            this.manifest = Object.assign(this.read(), this.manifest);
+        }
+
         File.find(this.path())
             .makeDirectories()
             .write(this.manifest);

--- a/src/config.js
+++ b/src/config.js
@@ -268,6 +268,13 @@ module.exports = function() {
                     return objValue.concat(srcValue);
                 }
             });
-        }
+        },
+
+      /**
+        * Merge the contents of the mix-manifest.json instead of rewriting the contents.
+        *
+        * @type {boolean}
+        */
+        mergeManifest: false,
     };
 };


### PR DESCRIPTION
This PR. resolved rewriting mix-manifest.json contents when use another mix file.

For example:
in `packages.json` file add scripts for combining dashboard assets :
```
{
  "scripts": {
     ...
     "dashboard:dev": "npm run development -- --env.mixfile=webpack.dashboard.mix.js",  
     "dashboard:watch": "npm run watch -- --env.mixfile=webpack.dashboard.mix.js",  
     "dashboard:prod": "npm run production -- --env.mixfile=webpack.dashboard.mix.js"
  }
  ...
}
```
then add `webpack.dashboard.mix.js` in the root of your project.
```
mix.js('resources/assets/js/dashboard.js', 'public/js')  
  .sass('resources/assets/sass/dashboard.scss', 'public/css')  
  .options({  
     mergeManifest: true  
  })
```

now if you run `npm run dashboard:dev` the dashboard assets will be appends to `mix-manifest.json` file instead of rewriting the contents