### PR TITLE
Updated the rootPath to the working directory of the node process.

### DIFF
--- a/src/Paths.js
+++ b/src/Paths.js
@@ -8,7 +8,7 @@ class Paths {
         if (argv['$0'].includes('ava')) {
             this.rootPath = path.resolve(__dirname, '../');
         } else {
-            this.rootPath = path.resolve(__dirname, '../../../');
+            this.rootPath = process.cwd();
         }
     }
 


### PR DESCRIPTION
Currently laravel-mix breaks when your `node_modules` directory is a symlink. This is due to the fact that relatives paths don't work when you are using a symlink because they will not point to your project root but will rather move relative to where your symlinked files are located.

A symlinked `node_modules` directory is pretty common when using a project with continuous integration where you are building on a production server. Examples of this are codeship or envoyer. When you are symlinking your `node_modules` directory you are not forced to rebuild it for every deploy which saves a lot of time and resources.

The documentation on process.cwd():

https://nodejs.org/docs/latest/api/process.html#process_process_cwd

This should help fix:

https://github.com/JeffreyWay/laravel-mix/issues/533
https://github.com/JeffreyWay/laravel-mix/issues/650
https://github.com/JeffreyWay/laravel-mix/issues/664

With this update the relative paths are completely removed and symlinks work perfectly fine.

I would love to get more input from more experience Node.js users on this request to see if this can lead to any potential drawbacks.