### PR TITLE
Set --production=false when installing additional deps

### DIFF
--- a/src/Dependencies.js
+++ b/src/Dependencies.js
@@ -46,10 +46,10 @@ class Dependencies {
         dependencies = [].concat(dependencies).join(' ');
 
         if (File.exists('yarn.lock')) {
-            return `yarn add ${dependencies} --dev`;
+            return `yarn add ${dependencies} --dev --production=false`;
         }
 
-        return `npm install ${dependencies} --save-dev`;
+        return `npm install ${dependencies} --save-dev --production=false`;
     }
 }
 


### PR DESCRIPTION
When `NODE_ENV` is `production`, devDependencies are not installed, which causes the issue described in #1728

The `--production` flag for [npm](https://docs.npmjs.com/cli/install) and [yarn](https://yarnpkg.com/lang/en/docs/cli/install/#toc-yarn-install-production-true-false) overrides the `NODE_ENV` value and ensures additional dependencies are installed even when `NODE_ENV` is `production`