### PR TITLE
Rename example component in workflow.md

### DIFF
--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -52,7 +52,7 @@ Excellent! Next, let's get to work. To watch your JavaScript for changes, run:
 npm run watch
 ```
 
-Laravel ships with a `./resources/assets/js/components/Example.vue` file. Give it a tweak, and wait for the OS notification, which signals that the compilation has completed. Great!
+Laravel ships with a `./resources/assets/js/components/ExampleComponent.vue` file. Give it a tweak, and wait for the OS notification, which signals that the compilation has completed. Great!
 
 > Tip: You may also use `mix.browserSync('myapp.test')` to automatically reload the browser when any relevant file in your Laravel app is changed.
 
@@ -71,7 +71,7 @@ Again, Laravel ships with a welcome page. We can use this for our demo. Update i
     </head>
     <body>
         <div id="app">
-            <example></example>
+            <example-component></example-component>
         </div>
 
         <script src="{{ mix('js/app.js') }}"></script>


### PR DESCRIPTION
Laravel now ships with ExampleComponent.vue instead of Example.vue