### PR TITLE
Remove new line at the end of written files

### DIFF
--- a/src/File.js
+++ b/src/File.js
@@ -1,4 +1,3 @@
-let os = require("os");
 let md5 = require('md5');
 let path = require('path');
 let fs = require('fs-extra');
@@ -151,8 +150,6 @@ class File {
         if (typeof body === 'object') {
             body = JSON.stringify(body, null, 4);
         }
-        
-        body = body + os.EOL;
 
         fs.writeFileSync(this.absolutePath, body);
 


### PR DESCRIPTION
Adding a new line to the generated hot file has stopped the Mix blade template helper from outputting the URL correctly since v2.1.11 when using HMR.

See issue #1773 for more details. 