### PR TITLE
Expose the OS system notification timeout to Laravel Mix Config

### DIFF
--- a/src/components/Notifications.js
+++ b/src/components/Notifications.js
@@ -12,6 +12,7 @@ class Notifications extends AutomaticComponent {
                 title: 'Laravel Mix',
                 alwaysNotify: Config.notifications.onSuccess,
                 hint: process.platform === 'linux' ? 'int:transient:1' : undefined,
+		timeout: Config.notifierTimeout != undefined ? Config.notifierTimeout : '5',
                 contentImage: Mix.paths.root(
                     'node_modules/laravel-mix/icons/laravel.png'
                 )

--- a/src/config.js
+++ b/src/config.js
@@ -256,6 +256,13 @@ module.exports = function() {
         clearConsole: true,
 
         /**
+         * Timeout value for OS system notifications
+         *
+         * @type {Integer String}
+         */
+	notifierTimeout: '1',
+
+        /**
          * Merge the given options with the current defaults.
          *
          * @param {object} options


### PR DESCRIPTION
Expose the OS system notification timeout to Laravel Mix Config, so that you can control the timeout from the Mix config