### PR TITLE
Check path using directory separator for active platform

### DIFF
--- a/src/builder/Entry.js
+++ b/src/builder/Entry.js
@@ -104,7 +104,7 @@ class Entry {
      */
     normalizePath(output, fallback) {
         // All output paths need to start at the project's public dir.
-        if (!output.pathFromPublic().startsWith('/' + Config.publicPath)) {
+        if (!output.pathFromPublic().startsWith(path.sep + Config.publicPath)) {
             output = new File(
                 path.join(Config.publicPath, output.pathFromPublic())
             );


### PR DESCRIPTION
By using `path.sep` instead of `'/'`, directories that should be part of the public path are now correctly detected as being so on Windows, which should resolve #1859.