### PR TITLE
Fix 1859 by preventing drive letters from being added to extraction paths

### DIFF
--- a/src/builder/Entry.js
+++ b/src/builder/Entry.js
@@ -104,7 +104,7 @@ class Entry {
      */
     normalizePath(output, fallback) {
         // All output paths need to start at the project's public dir.
-        if (!output.pathFromPublic().startsWith('/' + Config.publicPath)) {
+        if (!output.pathFromPublic().startsWith(path.sep + Config.publicPath)) {
             output = new File(
                 path.join(Config.publicPath, output.pathFromPublic())
             );

--- a/src/builder/Entry.js
+++ b/src/builder/Entry.js
@@ -114,7 +114,11 @@ class Entry {
      */
     normalizePath(output, fallback) {
         // All output paths need to start at the project's public dir.
-        if (!output.pathFromPublic().startsWith(path.sep + Config.publicPath)) {
+        let path = output.pathFromPublic();
+        if (
+            !path.startsWith('/' + Config.publicPath) &&
+            !path.startsWith('\\' + Config.publicPath)
+        ) {
             output = new File(
                 path.join(Config.publicPath, output.pathFromPublic())
             );

--- a/src/builder/Entry.js
+++ b/src/builder/Entry.js
@@ -58,12 +58,32 @@ class Entry {
             );
         }
 
-        let vendorPath = extraction.output
-            ? new File(extraction.output)
+        let toPrepend, outputPath;
+        // If the extraction output path begins with a slash (forward or backward)
+        // then the path from the public directory determined below will be wrong
+        // on Windows, as a drive letter will be incorrectly prepended to
+        // (e.g. '/dist/vendor' -> 'C:\dist\vendor').
+        if (['\\', '/'].indexOf(extraction.output[0]) >= 0) {
+            // In this case, remember the slash to prepend it to the vendor path
+            // after it has been determined relative to public...
+            toPrepend = extraction.output[0];
+            // ...and determine that path based on the input with the leading slash
+            // removed.
+            outputPath = extraction.output.substr(1);
+        } else {
+            // Otherwise, proceed as usual.
+            toPrepend = '';
+            outputPath = extraction.output;
+        }
+
+        let vendorPath = outputPath
+            ? new File(outputPath)
                   .pathFromPublic(Config.publicPath)
                   .replace(/\.js$/, '')
                   .replace(/\\/g, '/')
             : path.join(this.base, 'vendor').replace(/\\/g, '/');
+        // Add the leading slash back, if needed.
+        vendorPath = toPrepend + vendorPath;
 
         this.add(vendorPath, extraction.libs);
 

--- a/src/builder/Entry.js
+++ b/src/builder/Entry.js
@@ -58,23 +58,13 @@ class Entry {
             );
         }
 
-        let toPrepend, outputPath;
+        let outputPath = extraction.output;
         // If the extraction output path begins with a slash (forward or backward)
         // then the path from the public directory determined below will be wrong
         // on Windows, as a drive letter will be incorrectly prepended to
         // (e.g. '/dist/vendor' -> 'C:\dist\vendor').
-        if (['\\', '/'].indexOf(extraction.output[0]) >= 0) {
-            // In this case, remember the slash to prepend it to the vendor path
-            // after it has been determined relative to public...
-            toPrepend = extraction.output[0];
-            // ...and determine that path based on the input with the leading slash
-            // removed.
-            outputPath = extraction.output.substr(1);
-        } else {
-            // Otherwise, proceed as usual.
-            toPrepend = '';
-            outputPath = extraction.output;
-        }
+        let startsWithSlash = ['\\', '/'].indexOf(outputPath[0]) >= 0;
+        outputPath = startsWithSlash ? outputPath.substr(1) : outputPath;
 
         let vendorPath = outputPath
             ? new File(outputPath)
@@ -83,7 +73,7 @@ class Entry {
                   .replace(/\\/g, '/')
             : path.join(this.base, 'vendor').replace(/\\/g, '/');
         // Add the leading slash back, if needed.
-        vendorPath = toPrepend + vendorPath;
+        //vendorPath = toPrepend + vendorPath;
 
         this.add(vendorPath, extraction.libs);
 

--- a/src/components/Extract.js
+++ b/src/components/Extract.js
@@ -89,7 +89,7 @@ class Extract {
             }
         }
 
-        // If the use didn't specify any libraries to extract,
+        // If the user didn't specify any libraries to extract,
         // they likely want to extract all vendor libraries.
         if (Object.keys(config.cacheGroups).length === 0) {
             config.chunks = 'all';


### PR DESCRIPTION
The source of this issue with vendor extraction seems to have been the fact that `path.resolve` behaves differently on Windows when paths that are (or look) absolute are involved.

Specifically, `path.resolve('/dist/js/vendor')` will leave the input unchanged and return `'/dist/js/vendor'` on Linux/Mac, but will alter it to `'C:\dist\js\vendor'` (or `'D:\...`, etc.) on Windows. This actually means that two of the existing extraction tests were failing on Windows (test output below).

To resolve the problem, the `Entry.addExtraction` method now checks whether the intended output path begins with a slash (either forward or backward). If it does, the slash is removed.

With this change in place, all three extraction tests pass in both Windows and linux environments. Additionally, my production application that was hanging at 95% during compilation, now compiles successfully again.

## Other notes

* `Entry.normalizePath` has been switched away from using `path.sep` to checking both slashes explicitly, since some inputs may have already had their backslashes replaced by forward slashes. I didn't have a specific instance in which using `path.sep` failed, but this seems safer.

* There was a minor typo in a comment that said "If the use..." instead of "If the user...", so it's fixed.

---

## Tests

Both sets of output below were copied and pasted from the same Windows development environment, before and after applying this patch.

### Original test output showing two failures during extraction

```
$ npm test test\features\extraction.js

> laravel-mix@4.0.6 test D:\Work\Projects\code\github\laravel-mix
> nyc ava --verbose --serial "test\features\extraction.js"

  × JS compilation with vendor extraction config
  √ vendor extraction with no requested JS compilation will still extract vendor libraries
  × JS compilation with vendor extraction with default config

  2 tests failed

  JS compilation with vendor extraction config

  D:\Work\Projects\code\github\laravel-mix\test\features\extraction.js:9

   8:
   9:     t.deepEqual(
   10:         {

  Difference:

    {
      '/js/app': Array [ … ],
  -   '/js/libraries': Array [ … ],
  +   'D:/js/libraries': Array [ … ],
    }

  Test.deepEqual [as fn] (test/features/extraction.js:9:7)
  processEmit [as emit] (node_modules/nyc/node_modules/signal-exit/index.js:155:32)
  processEmit [as emit] (node_modules/nyc/node_modules/signal-exit/index.js:155:32)



  JS compilation with vendor extraction with default config

  D:\Work\Projects\code\github\laravel-mix\test\features\extraction.js:38

   37:
   38:     t.deepEqual(
   39:         {

  Difference:

    {
      '/js/app': Array [ … ],
  -   '/js/vendor': Array [ … ],
  +   'D:/js/vendor': Array [ … ],
    }

  Test.deepEqual [as fn] (test/features/extraction.js:38:7)
  processEmit [as emit] (node_modules/nyc/node_modules/signal-exit/index.js:155:32)
  processEmit [as emit] (node_modules/nyc/node_modules/signal-exit/index.js:155:32)
```


### New test output showing successful extraction

```
$ npm test test\features\extraction.js


> laravel-mix@4.0.6 test D:\Work\Projects\code\github\laravel-mix
> nyc ava --verbose --serial "test\features\extraction.js"


  √ JS compilation with vendor extraction config (300ms)
  √ vendor extraction with no requested JS compilation will still extract vendor libraries
  √ JS compilation with vendor extraction with default config

  3 tests passed
```