### PR TITLE
Change Mix's default OS system notification timeout to 2 seconds

### DIFF
--- a/src/components/Notifications.js
+++ b/src/components/Notifications.js
@@ -15,6 +15,7 @@ class Notifications extends AutomaticComponent {
                     process.platform === 'linux'
                         ? 'int:transient:1'
                         : undefined,
+		timeout: 2,
                 contentImage: Mix.paths.root(
                     'node_modules/laravel-mix/icons/laravel.png'
                 )


### PR DESCRIPTION
Change Mix's default OS system notification timeout to 2 seconds, 5 seconds is too long of a wait time