### PR TITLE
Updated webpack-dev-server package (Fixes security notice)

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1520,9 +1520,9 @@
             }
         },
         "ansi-colors": {
-            "version": "3.2.1",
-            "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.1.tgz",
-            "integrity": "sha512-Xt+zb6nqgvV9SWAVp0EG3lRsHcbq5DDgqjPPz6pwgtj6RKz65zGXMNa82oJfOSBA/to6GmRP7Dr+6o+kbApTzQ=="
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.3.tgz",
+            "integrity": "sha512-LEHHyuhlPY3TmuUYMh2oz89lTShfvgbmzaBcxve9t/9Wuy7Dwf4yoAKcND7KFT1HAQfqZ12qtc+DUrBMeKF9nw=="
         },
         "ansi-escapes": {
             "version": "3.1.0",
@@ -1604,9 +1604,9 @@
             "dev": true
         },
         "array-flatten": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-2.1.1.tgz",
-            "integrity": "sha1-Qmu52oQJDBg42BLIFQryCoMx4pY="
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-2.1.2.tgz",
+            "integrity": "sha512-hNfzcOV8W4NdualtqBFPyVO+54DSJuZGY9qT4pRroB6S9e3iiido2ISIC5h9R2sPJ8H3FHCIiEnsv1lPXO3KtQ=="
         },
         "array-from": {
             "version": "2.1.1",
@@ -3516,9 +3516,9 @@
             }
         },
         "connect-history-api-fallback": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.5.0.tgz",
-            "integrity": "sha1-sGhzk0vF40T+9hGhlqb6rgruAVo="
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.6.0.tgz",
+            "integrity": "sha512-e54B99q/OUoH64zYYRf3HBP5z24G38h5D3qXu23JGRoigpX5Ss4r9ZnDk3g0Z8uQC2x2lPaJ+UlWBc1ZWBWdLg=="
         },
         "console-browserify": {
             "version": "1.1.0",
@@ -3677,6 +3677,18 @@
                 "ripemd160": "^2.0.0",
                 "safe-buffer": "^5.0.1",
                 "sha.js": "^2.4.8"
+            }
+        },
+        "cross-spawn": {
+            "version": "6.0.5",
+            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+            "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+            "requires": {
+                "nice-try": "^1.0.4",
+                "path-key": "^2.0.1",
+                "semver": "^5.5.0",
+                "shebang-command": "^1.2.0",
+                "which": "^1.2.9"
             }
         },
         "crypt": {
@@ -4041,18 +4053,6 @@
                 "ip-regex": "^2.1.0"
             },
             "dependencies": {
-                "cross-spawn": {
-                    "version": "6.0.5",
-                    "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-                    "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
-                    "requires": {
-                        "nice-try": "^1.0.4",
-                        "path-key": "^2.0.1",
-                        "semver": "^5.5.0",
-                        "shebang-command": "^1.2.0",
-                        "which": "^1.2.9"
-                    }
-                },
                 "execa": {
                     "version": "0.10.0",
                     "resolved": "https://registry.npmjs.org/execa/-/execa-0.10.0.tgz",
@@ -4999,9 +4999,9 @@
             "dev": true
         },
         "follow-redirects": {
-            "version": "1.5.10",
-            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
-            "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.6.1.tgz",
+            "integrity": "sha512-t2JCjbzxQpWvbhts3l6SH1DKzSrx8a+SsaVf4h6bG4kOXUuPYS/kg2Lr4gQSb7eemaHqJkOThF1BGyjlUkO1GQ==",
             "requires": {
                 "debug": "=3.1.0"
             },
@@ -5862,9 +5862,9 @@
             "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE="
         },
         "handle-thing": {
-            "version": "1.2.5",
-            "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-1.2.5.tgz",
-            "integrity": "sha1-/Xqtcmvxpf0W38KbL3pmAdJxOcQ="
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-2.0.0.tgz",
+            "integrity": "sha512-d4sze1JNC454Wdo2fkuyzCr6aHcbL6PGGuFAz0Li/NcOm1tCHGnWDRmJP85dh9IhQErTc2svWFEX5xHIOo//kQ=="
         },
         "har-schema": {
             "version": "2.0.0",
@@ -9384,6 +9384,53 @@
             "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
             "dev": true
         },
+        "os-locale": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
+            "integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
+            "requires": {
+                "execa": "^1.0.0",
+                "lcid": "^2.0.0",
+                "mem": "^4.0.0"
+            },
+            "dependencies": {
+                "execa": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+                    "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
+                    "requires": {
+                        "cross-spawn": "^6.0.0",
+                        "get-stream": "^4.0.0",
+                        "is-stream": "^1.1.0",
+                        "npm-run-path": "^2.0.0",
+                        "p-finally": "^1.0.0",
+                        "signal-exit": "^3.0.0",
+                        "strip-eof": "^1.0.0"
+                    }
+                },
+                "get-stream": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+                    "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+                    "requires": {
+                        "pump": "^3.0.0"
+                    }
+                },
+                "invert-kv": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
+                    "integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA=="
+                },
+                "lcid": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
+                    "integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
+                    "requires": {
+                        "invert-kv": "^2.0.0"
+                    }
+                }
+            }
+        },
         "os-tmpdir": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
@@ -9712,9 +9759,9 @@
             }
         },
         "portfinder": {
-            "version": "1.0.19",
-            "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.19.tgz",
-            "integrity": "sha512-23aeQKW9KgHe6citUrG3r9HjeX6vls0h713TAa+CwTKZwNIr/pD2ApaxYF4Um3ZZyq4ar+Siv3+fhoHaIwSOSw==",
+            "version": "1.0.20",
+            "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.20.tgz",
+            "integrity": "sha512-Yxe4mTyDzTd59PZJY4ojZR8F+E5e97iq2ZOHPz3HDgSvYC5siNad2tLooQ5y5QHyQhc3xVqvyk/eNA3wuoa7Sw==",
             "requires": {
                 "async": "^1.5.2",
                 "debug": "^2.2.0",
@@ -11636,30 +11683,68 @@
             "dev": true
         },
         "spdy": {
-            "version": "3.4.7",
-            "resolved": "https://registry.npmjs.org/spdy/-/spdy-3.4.7.tgz",
-            "integrity": "sha1-Qv9B7OXMD5mjpsKKq7c/XDsDrLw=",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/spdy/-/spdy-4.0.0.tgz",
+            "integrity": "sha512-ot0oEGT/PGUpzf/6uk4AWLqkq+irlqHXkrdbk51oWONh3bxQmBuljxPNl66zlRRcIJStWq0QkLUCPOPjgjvU0Q==",
             "requires": {
-                "debug": "^2.6.8",
-                "handle-thing": "^1.2.5",
+                "debug": "^4.1.0",
+                "handle-thing": "^2.0.0",
                 "http-deceiver": "^1.2.7",
-                "safe-buffer": "^5.0.1",
                 "select-hose": "^2.0.0",
-                "spdy-transport": "^2.0.18"
+                "spdy-transport": "^3.0.0"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "4.1.1",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+                    "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
+                },
+                "ms": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+                    "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+                }
             }
         },
         "spdy-transport": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-2.1.1.tgz",
-            "integrity": "sha512-q7D8c148escoB3Z7ySCASadkegMmUZW8Wb/Q1u0/XBgDKMO880rLQDj8Twiew/tYi7ghemKUi/whSYOwE17f5Q==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-3.0.0.tgz",
+            "integrity": "sha512-hsLVFE5SjA6TCisWeJXFKniGGOpBgMLmerfO2aCyCU5s7nJ/rpAepqmFifv/GCbSbueEeAJJnmSQ2rKC/g8Fcw==",
             "requires": {
-                "debug": "^2.6.8",
-                "detect-node": "^2.0.3",
+                "debug": "^4.1.0",
+                "detect-node": "^2.0.4",
                 "hpack.js": "^2.1.6",
-                "obuf": "^1.1.1",
-                "readable-stream": "^2.2.9",
-                "safe-buffer": "^5.0.1",
-                "wbuf": "^1.7.2"
+                "obuf": "^1.1.2",
+                "readable-stream": "^3.0.6",
+                "wbuf": "^1.7.3"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "4.1.1",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+                    "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
+                },
+                "ms": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+                    "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+                },
+                "readable-stream": {
+                    "version": "3.1.1",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.1.1.tgz",
+                    "integrity": "sha512-DkN66hPyqDhnIQ6Jcsvx9bFjhw214O4poMBcIMgPVpQvNy9a0e0Uhg5SqySyDKAmUlwt8LonTBz1ezOnM8pUdA==",
+                    "requires": {
+                        "inherits": "^2.0.3",
+                        "string_decoder": "^1.1.1",
+                        "util-deprecate": "^1.0.1"
+                    }
+                }
             }
         },
         "split-string": {
@@ -12840,9 +12925,9 @@
             }
         },
         "webpack-dev-server": {
-            "version": "3.1.10",
-            "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.1.10.tgz",
-            "integrity": "sha512-RqOAVjfqZJtQcB0LmrzJ5y4Jp78lv9CK0MZ1YJDTaTmedMZ9PU9FLMQNrMCfVu8hHzaVLVOJKBlGEHMN10z+ww==",
+            "version": "3.1.14",
+            "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.1.14.tgz",
+            "integrity": "sha512-mGXDgz5SlTxcF3hUpfC8hrQ11yhAttuUQWf1Wmb+6zo3x6rb7b9mIfuQvAPLdfDRCGRGvakBWHdHOa0I9p/EVQ==",
             "requires": {
                 "ansi-html": "0.0.7",
                 "bonjour": "^3.5.0",
@@ -12863,37 +12948,23 @@
                 "portfinder": "^1.0.9",
                 "schema-utils": "^1.0.0",
                 "selfsigned": "^1.9.1",
+                "semver": "^5.6.0",
                 "serve-index": "^1.7.2",
                 "sockjs": "0.3.19",
                 "sockjs-client": "1.3.0",
-                "spdy": "^3.4.1",
+                "spdy": "^4.0.0",
                 "strip-ansi": "^3.0.0",
                 "supports-color": "^5.1.0",
+                "url": "^0.11.0",
                 "webpack-dev-middleware": "3.4.0",
                 "webpack-log": "^2.0.0",
                 "yargs": "12.0.2"
             },
             "dependencies": {
-                "ajv": {
-                    "version": "6.5.5",
-                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.5.tgz",
-                    "integrity": "sha512-7q7gtRQDJSyuEHjuVgHoUa2VuemFiCMrfQc9Tc08XTAc4Zj/5U1buQJ0HU6i7fKjXU09SVgSmxa4sLvuvS8Iyg==",
-                    "requires": {
-                        "fast-deep-equal": "^2.0.1",
-                        "fast-json-stable-stringify": "^2.0.0",
-                        "json-schema-traverse": "^0.4.1",
-                        "uri-js": "^4.2.2"
-                    }
-                },
                 "ansi-regex": {
                     "version": "3.0.0",
                     "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
                     "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
-                },
-                "camelcase": {
-                    "version": "4.1.0",
-                    "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-                    "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
                 },
                 "cliui": {
                     "version": "4.1.0",
@@ -12915,18 +12986,6 @@
                         }
                     }
                 },
-                "cross-spawn": {
-                    "version": "6.0.5",
-                    "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-                    "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
-                    "requires": {
-                        "nice-try": "^1.0.4",
-                        "path-key": "^2.0.1",
-                        "semver": "^5.5.0",
-                        "shebang-command": "^1.2.0",
-                        "which": "^1.2.9"
-                    }
-                },
                 "debug": {
                     "version": "3.2.6",
                     "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
@@ -12943,49 +13002,12 @@
                         "xregexp": "4.0.0"
                     }
                 },
-                "execa": {
-                    "version": "0.10.0",
-                    "resolved": "https://registry.npmjs.org/execa/-/execa-0.10.0.tgz",
-                    "integrity": "sha512-7XOMnz8Ynx1gGo/3hyV9loYNPWM94jG3+3T3Y8tsfSstFmETmENCMU/A/zj8Lyaj1lkgEepKepvd6240tBRvlw==",
-                    "requires": {
-                        "cross-spawn": "^6.0.0",
-                        "get-stream": "^3.0.0",
-                        "is-stream": "^1.1.0",
-                        "npm-run-path": "^2.0.0",
-                        "p-finally": "^1.0.0",
-                        "signal-exit": "^3.0.0",
-                        "strip-eof": "^1.0.0"
-                    }
-                },
-                "fast-deep-equal": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-                    "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
-                },
                 "find-up": {
                     "version": "3.0.0",
                     "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
                     "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
                     "requires": {
                         "locate-path": "^3.0.0"
-                    }
-                },
-                "invert-kv": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
-                    "integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA=="
-                },
-                "json-schema-traverse": {
-                    "version": "0.4.1",
-                    "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-                    "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
-                },
-                "lcid": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
-                    "integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
-                    "requires": {
-                        "invert-kv": "^2.0.0"
                     }
                 },
                 "locate-path": {
@@ -13002,20 +13024,10 @@
                     "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
                     "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
                 },
-                "os-locale": {
-                    "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.0.1.tgz",
-                    "integrity": "sha512-7g5e7dmXPtzcP4bgsZ8ixDVqA7oWYuEz4lOSujeWyliPai4gfVDiFIcwBg3aGCPnmSGfzOKTK3ccPn0CKv3DBw==",
-                    "requires": {
-                        "execa": "^0.10.0",
-                        "lcid": "^2.0.0",
-                        "mem": "^4.0.0"
-                    }
-                },
                 "p-limit": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.0.0.tgz",
-                    "integrity": "sha512-fl5s52lI5ahKCernzzIyAP0QAZbGIovtVHGwpcu1Jr/EpzLVDI2myISHwGqK7m8uQFugVWSrbxH7XnhGtvEc+A==",
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.1.0.tgz",
+                    "integrity": "sha512-NhURkNcrVB+8hNfLuysU8enY5xn2KXphsHBaC2YmRNTZRc7RWusw6apSpdEj3jo4CMb6W9nrF6tTnsJsJeyu6g==",
                     "requires": {
                         "p-try": "^2.0.0"
                     }
@@ -13032,21 +13044,6 @@
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.0.0.tgz",
                     "integrity": "sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ=="
-                },
-                "schema-utils": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
-                    "integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
-                    "requires": {
-                        "ajv": "^6.1.0",
-                        "ajv-errors": "^1.0.0",
-                        "ajv-keywords": "^3.1.0"
-                    }
-                },
-                "which-module": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-                    "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
                 },
                 "yargs": {
                     "version": "12.0.2",
@@ -13065,14 +13062,6 @@
                         "which-module": "^2.0.0",
                         "y18n": "^3.2.1 || ^4.0.0",
                         "yargs-parser": "^10.1.0"
-                    }
-                },
-                "yargs-parser": {
-                    "version": "10.1.0",
-                    "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-10.1.0.tgz",
-                    "integrity": "sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==",
-                    "requires": {
-                        "camelcase": "^4.1.0"
                     }
                 }
             }
@@ -13146,6 +13135,11 @@
             "requires": {
                 "isexe": "^2.0.0"
             }
+        },
+        "which-module": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+            "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
         },
         "widest-line": {
             "version": "2.0.1",
@@ -13434,6 +13428,21 @@
                         "camelcase": "^5.0.0",
                         "decamelize": "^1.2.0"
                     }
+                }
+            }
+        },
+        "yargs-parser": {
+            "version": "10.1.0",
+            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-10.1.0.tgz",
+            "integrity": "sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==",
+            "requires": {
+                "camelcase": "^4.1.0"
+            },
+            "dependencies": {
+                "camelcase": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+                    "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
                 }
             }
         }

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
         "vue-loader": "^15.4.2",
         "webpack": "^4.27.1",
         "webpack-cli": "^3.1.2",
-        "webpack-dev-server": "^3.1.10",
+        "webpack-dev-server": "^3.1.14",
         "webpack-merge": "^4.1.0",
         "webpack-notifier": "^1.5.1",
         "yargs": "^12.0.5"


### PR DESCRIPTION
Fixes security flaw present at `webpack-dev-server` package, described at https://www.npmjs.com/advisories/725

### Audit Output

```
                                                                                
                       === npm audit security report ===                        
                                                                                
# Run  npm install webpack-dev-server@3.1.14  to resolve 1 vulnerability
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ High          │ Missing Origin Validation                                    │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ webpack-dev-server                                           │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ webpack-dev-server                                           │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ webpack-dev-server                                           │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://nodesecurity.io/advisories/725                       │
└───────────────┴──────────────────────────────────────────────────────────────┘
```