### PR TITLE
Reduce build time by tweaking terser configs

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -160,6 +160,8 @@ module.exports = function() {
          * @type {Object}
          */
         terser: {
+            cache: true,
+            parallel: true,
             sourceMap: true,
             terserOptions: {
                 compress: {


### PR DESCRIPTION
**Enabling `cache`  for terser (uglify-js) will reduce build time to 50%**

https://github.com/webpack-contrib/terser-webpack-plugin#cache

**Enabling `parallel` option will take advantage of multi-process when available.**

https://github.com/webpack-contrib/terser-webpack-plugin#parallel 

Laravel Mix is already using cache for babel-loader.
