### PR TITLE
Allow dot in directory name when using copy

### DIFF
--- a/src/File.js
+++ b/src/File.js
@@ -248,18 +248,28 @@ class File {
      */
     parse() {
         let parsed = path.parse(this.absolutePath);
-
+        let isDir=this.checkIsDirectory(parsed);
         return {
             path: this.filePath,
             absolutePath: this.absolutePath,
             pathWithoutExt: path.join(parsed.dir, `${parsed.name}`),
-            isDir: !parsed.ext && !parsed.name.endsWith('*'),
-            isFile: !!parsed.ext,
+            isDir: isDir,
+            isFile: !isDir && !!parsed.ext,
             name: parsed.name,
             ext: parsed.ext,
             file: parsed.base,
             base: parsed.dir
         };
+    }
+    /**
+     * check if the path is a directory
+     * @param parsed
+     */
+    checkIsDirectory(parsed){
+        if(fs.existsSync(this.absolutePath)){
+            return fs.lstatSync(this.absolutePath).isDirectory();
+        }
+        return !parsed.ext && !parsed.name.endsWith('*');
     }
 }
 

--- a/src/File.js
+++ b/src/File.js
@@ -248,7 +248,7 @@ class File {
      */
     parse() {
         let parsed = path.parse(this.absolutePath);
-        let isDir=this.checkIsDirectory(parsed);
+        let isDir = this.checkIsDirectory(parsed);
         return {
             path: this.filePath,
             absolutePath: this.absolutePath,
@@ -261,12 +261,13 @@ class File {
             base: parsed.dir
         };
     }
+    
     /**
      * check if the path is a directory
      * @param parsed
      */
-    checkIsDirectory(parsed){
-        if(fs.existsSync(this.absolutePath)){
+    checkIsDirectory(parsed) {
+        if (fs.existsSync(this.absolutePath)) {
             return fs.lstatSync(this.absolutePath).isDirectory();
         }
         return !parsed.ext && !parsed.name.endsWith('*');


### PR DESCRIPTION
When coping directories, it whas checking only the string name of the file / directory, but, if there is a dot in the name, than it thinks that is a file.
Whith this change, it will first check if the path file exist, after that will check if is a directory using file system (fs).
Case positive, just confirm, if not, will check using the old method, analising the string.