### PR TITLE
Allow use dynamic import

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     ],
     "dependencies": {
         "@babel/core": "^7.2.0",
+        "@babel/plugin-syntax-dynamic-import": "^7.2.0",
         "@babel/plugin-proposal-object-rest-spread": "^7.2.0",
         "@babel/plugin-transform-runtime": "^7.2.0",
         "@babel/preset-env": "^7.2.0",
@@ -68,7 +69,6 @@
         "yargs": "^12.0.5"
     },
     "devDependencies": {
-        "@babel/plugin-syntax-dynamic-import": "^7.2.0",
         "@babel/preset-react": "^7.0.0",
         "ava": "^0.25.0",
         "coffee-loader": "^0.9.0",

--- a/src/BabelConfig.js
+++ b/src/BabelConfig.js
@@ -46,6 +46,7 @@ class BabelConfig {
                 ]
             ],
             plugins: [
+                '@babel/plugin-syntax-dynamic-import',
                 '@babel/plugin-proposal-object-rest-spread',
                 [
                     '@babel/plugin-transform-runtime',

--- a/src/builder/webpack-default.js
+++ b/src/builder/webpack-default.js
@@ -9,7 +9,9 @@ module.exports = function() {
 
         entry: {},
 
-        output: {},
+        output: {
+            chunkFilename: '[name].[hash:5].js'
+        },
 
         module: { rules: [] },
 

--- a/test/features/javascript.js
+++ b/test/features/javascript.js
@@ -15,6 +15,21 @@ test.cb.serial('it compiles JavaScript', t => {
     });
 });
 
+test.cb.serial('it compiles JavaScript with dynamic import', t => {
+    mix.js('test/fixtures/fake-app/resources/assets/dynamic/dynamic.js', 'js');
+
+    compile(t, () => {
+        t.true(File.exists('test/fixtures/fake-app/public/js/dynamic.js'));
+
+        t.deepEqual(
+            {
+                '/js/dynamic.js': '/js/dynamic.js'
+            },
+            readManifest()
+        );
+    });
+});
+
 test.cb.serial('it compiles JavaScript and Sass', t => {
     mix.js('test/fixtures/fake-app/resources/assets/js/app.js', 'js').sass(
         'test/fixtures/fake-app/resources/assets/sass/app.scss',

--- a/test/fixtures/fake-app/resources/assets/dynamic/dynamic-module.js
+++ b/test/fixtures/fake-app/resources/assets/dynamic/dynamic-module.js
@@ -1,0 +1,7 @@
+const dynamic = {
+    init: () => {
+        alert('dynamic test');
+    }
+};
+
+export default dynamic;

--- a/test/fixtures/fake-app/resources/assets/dynamic/dynamic.js
+++ b/test/fixtures/fake-app/resources/assets/dynamic/dynamic.js
@@ -1,0 +1,1 @@
+import('./dynamic-module').then(module => module.init());


### PR DESCRIPTION
With this changes we can use dynamic import by default.

https://webpack.js.org/guides/code-splitting/#dynamic-imports

this is useful if you want to split modules into chunks and connect them dynamically only where you need.

for example:
```js
if (document.getElementById('root') {
  import('./module.js').then(module => module.init());
}
```