### PR TITLE
Support import .vue SFC from node_modules

### DIFF
--- a/src/components/Vue.js
+++ b/src/components/Vue.js
@@ -29,7 +29,20 @@ class Vue {
 
         webpackConfig.plugins.push(new VueLoaderPlugin());
 
+        this.updateJsLoaders(webpackConfig);
         this.updateCssLoaders(webpackConfig);
+    }
+
+    /**
+     * Update JS loaders.
+     *
+     * @param {Object} webpackConfig
+     */
+    updateJsLoaders(webpackConfig) {
+        let rule = webpackConfig.module.rules.find(rule => {
+            return rule.test instanceof RegExp && rule.test.test('.js');
+        });
+        rule.exclude = { and: [rule.exclude, { not: [/\.vue\.js$/] }] };
     }
 
     /**


### PR DESCRIPTION
Currently JavaScript component excludes all imports from node_modules for transformation with babel. This breaks .vue Single File Components (SFC) imported from node_modules with script blocks (which through vue-loader generates new modules imports as '/node_modules/[..].vue.js').