### PR TITLE
Fixed HMR on Windows

### DIFF
--- a/src/builder/WebpackConfig.js
+++ b/src/builder/WebpackConfig.js
@@ -59,7 +59,7 @@ class WebpackConfig {
         }
 
         this.webpackConfig.output = {
-            path: path.resolve(Mix.isUsing('hmr') ? '/' : Config.publicPath),
+            path: Mix.isUsing('hmr') ? '/' : path.resolve(Config.publicPath),
             filename: '[name].js',
             chunkFilename: '[name].js',
             publicPath: Mix.isUsing('hmr')


### PR DESCRIPTION
Currently on Windows HMR does not work:

How to reproduce:
- delete js/css outputs
- run `npm run hot`

You will get 404 errors.

The following section: `path.resolve(Mix.isUsing('hmr') ? '/' : Config.publicPath)` 
will result on `D:\\` instead of the expected `/`, where `D` is the windows drive letter.

Expected: (linux, mac)
```js
output: {
  path: '/',
  filename: '[name].js',
  chunkFilename: '[name].js',
  publicPath: 'http://localhost:8080/'
}
```

Windows:
```js
output: {
  path: 'D:\\',
  filename: '[name].js',
  chunkFilename: '[name].js',
  publicPath: 'http://localhost:8080/'
}
```

This fixes: #1993