### PR TITLE
Generate css files with HMR

### DIFF
--- a/src/components/Preprocessor.js
+++ b/src/components/Preprocessor.js
@@ -88,14 +88,19 @@ class Preprocessor {
                     });
                 }
 
+                const applyLoaders = (hmr, loaders) => {
+                    loaders = extractPlugin.extract({
+                        fallback: 'style-loader',
+                        use: loaders,
+                        remove: !hmr
+                    })
+
+                    return hmr ? ['style-loader', ...loaders] : loaders
+                }
+
                 rules.push({
                     test: preprocessor.src.path(),
-                    use: Mix.isUsing('hmr')
-                        ? ['style-loader', ...loaders]
-                        : extractPlugin.extract({
-                              fallback: 'style-loader',
-                              use: loaders
-                          })
+                    use: applyLoaders(Mix.isUsing('hmr'), loaders)
                 });
 
                 this.extractPlugins = (this.extractPlugins || []).concat(


### PR DESCRIPTION
## What is the problem ?
#1743 Introduced hot-reload for styles, but in the process **broke** the generation of the **css files**.

Worked before with `--hot`:
- `<link href="{{ mix('css/app.css') }}"`

The above example gives a **404** now.

## Why is it a problem ?

- you have critical css which needs to be loaded before the js.
- you make js size calculation on dom elements, the hot styles will kick in too late

## How is it fixed ?

The styles are always (with/without `--hot`) passed through **ExtractTextPlugin**

If `--hot` is passed the output of the  **ExtractTextPlugin** will not be removed, but passed to the  **style-loader**, otherwise it will be removed.
```js
const applyLoaders = (hmr, loaders) => {
  loaders = extractPlugin.extract({
    fallback: 'style-loader',
    use: loaders,
    remove: !hmr
  })

  return hmr ? ['style-loader', ...loaders] : loaders
}
```

Follow up of #1995 
