### PR TITLE
Prefer `process.env.${key}` when defining values

### DIFF
--- a/src/webpackPlugins/MixDefinitionsPlugin.js
+++ b/src/webpackPlugins/MixDefinitionsPlugin.js
@@ -45,15 +45,15 @@ MixDefinitionsPlugin.prototype.getDefinitions = function(merge) {
 
     let values = Object.assign(env, merge);
 
-    return {
-        'process.env': Object.keys(values)
+    return (
+        Object.keys(values)
             // Stringify all values so they can be fed into Webpack's DefinePlugin.
             .reduce((value, key) => {
-                value[key] = JSON.stringify(values[key]);
+                value[`process.env.${key}`] = JSON.stringify(values[key]);
 
                 return value;
             }, {})
-    };
+    );
 };
 
 module.exports = MixDefinitionsPlugin;

--- a/test/plugins/MixDefinitionsPlugin.js
+++ b/test/plugins/MixDefinitionsPlugin.js
@@ -14,6 +14,6 @@ test('it fetches the MIX_ definitions properly', t => {
 
     // Note that the definitions may contain more keys.
     // During a travis build with cached node modules, there's a MIX_ARCHIVES entry, for example.
-    t.is(MIX_TESTING, definitions['process.env'].MIX_TESTING);
-    t.is(NODE_ENV, definitions['process.env'].NODE_ENV);
+    t.is(MIX_TESTING, definitions['process.env.MIX_TESTING']);
+    t.is(NODE_ENV, definitions['process.env.NODE_ENV']);
 });


### PR DESCRIPTION
Prefer `process.env.${key}` when defining values to avoid overwriting the process object.

At the moment trying to access any non-existent process.env variable results in the full replacement object being compiled.

For example:
```javascript
 let doesNotExist = process.env.DOES_NOT_EXIST
```
Compiles to:
```javascript
var doesNotExist = Object({"NODE_ENV":"development"}).DOES_NOT_EXIST;
```

The recommended usage of the `DefinePlugin` at https://webpack.js.org/plugins/define-plugin/ is:

> When defining values for `process` prefer `'process.env.NODE_ENV': JSON.stringify('production')` over `process: { env: { NODE_ENV: JSON.stringify('production') } }`. Using the latter will overwrite the `process` object which can break compatibility with some modules that expect other values on the process object to be defined.

This PR follows the guidance and is similar to [EnvironmentPlugin](https://github.com/webpack/webpack/blob/685a0626cb10664133ef2fb2e2f9f4cb3971402a/lib/EnvironmentPlugin.js#L62)

I came across this because some third party modules where trying to access variables I haven't defined e.g. `process.env.DEBUG` and I noticed all by MIX_ variables. This does mean the `process` shim will be included if a script tried to access a non-replaced variable (which is the behaviour without the plugin).