### PR TITLE
Transform tabs into spaces

### DIFF
--- a/src/components/Notifications.js
+++ b/src/components/Notifications.js
@@ -15,6 +15,7 @@ class Notifications extends AutomaticComponent {
                     process.platform === 'linux'
                         ? 'int:transient:1'
                         : undefined,
+                timeout: 2,
                 contentImage: Mix.paths.root(
                     'node_modules/laravel-mix/icons/laravel.png'
                 )


### PR DESCRIPTION
While reading the `Notifications.js`, I found some unexpected indents using tabs. This pull request transforms them into spaces.