### PR TITLE
fix: remove loaderOption (migration is done)

### DIFF
--- a/src/builder/webpack-plugins.js
+++ b/src/builder/webpack-plugins.js
@@ -32,19 +32,6 @@ module.exports = function() {
         })
     );
 
-    // Add some general Webpack loader options.
-    plugins.push(
-        new webpack.LoaderOptionsPlugin({
-            minimize: Mix.isUsing('purifyCss') ? false : Mix.inProduction(),
-            options: {
-                context: __dirname,
-                output: {
-                    path: './'
-                }
-            }
-        })
-    );
-
     // Handle all custom, non-webpack tasks.
     plugins.push(new ManifestPlugin());
 


### PR DESCRIPTION
As `svelte` can't work using `laravel-mix`, the usage of `loaderOption` seems deprecated is our case (webpack 4) and doesn't need to pass options to every loader anymore