### PR TITLE
Make Browsersync use publicPath for watching js/css

### DIFF
--- a/src/components/Browsersync.js
+++ b/src/components/Browsersync.js
@@ -46,8 +46,7 @@ class Browsersync {
                 files: [
                     'app/**/*.php',
                     'resources/views/**/*.php',
-                    'public/js/**/*.js',
-                    'public/css/**/*.css'
+                    `${Config.publicPath || 'public'}/**/*.(js|css)`
                 ],
                 snippetOptions: {
                     rule: {


### PR DESCRIPTION
The default Browsersync config will use `public` for watching JS and CSS changes even if the Mix user has changed their `publicPath`. This uses the user-defined `publicPath` but falls back to `public` if nothing is set. It also doesn’t assume directory names for the JS and CSS. This saves Mix users from needing to pass an config to the Browsersync component.