### PR TITLE
Allow manifest files to handle sub directory installation

### DIFF
--- a/src/Api.js
+++ b/src/Api.js
@@ -46,7 +46,18 @@ class Api {
 
         return this;
     }
+    
+    /**
+     * Set a root directory for a project in a subdirectory
+     *
+     * @param {string} defaultPath
+     */
+    setRootSubdirectory(defaultPath) {
+        Config.rootSubdirectory = path.normalize(defaultPath.replace(/\/$/, ''));
 
+        return this;
+    }
+    
     /**
      * Merge custom config with the provided webpack.config file.
      *

--- a/src/Manifest.js
+++ b/src/Manifest.js
@@ -52,8 +52,9 @@ class Manifest {
         let hash = new File(path.join(Config.publicPath, file)).version();
 
         let filePath = this.normalizePath(file);
+        let subdirectory = this.normalizePath(Config.rootSubdirectory);
 
-        this.manifest[filePath] = filePath + '?id=' + hash;
+        this.manifest[filePath] = path.join(subdirectory, filePath) + '?id=' + hash; 
 
         return this;
     }

--- a/src/config.js
+++ b/src/config.js
@@ -87,6 +87,14 @@ module.exports = function() {
         resourceRoot: '/',
 
         /**
+         * The root directory your project if it is installed within a
+         * subdirectory e.g. /var/www/[subdirectory]/
+         *
+         * @type {String}
+         */
+        rootSubdirectory: '', 
+        
+        /**
          * Image Loader defaults.
          * See: https://github.com/thetalecrafter/img-loader#options
          *


### PR DESCRIPTION
If you have Laravel installed in a sub directory from your server root directory (e.g. /var/www/blog/) the mix-manifest.js file doesn't correctly hold the path to your assets because it omits the sub directory. Additionally setPublicPath and setResourceRoot are used in other places so those aren't options for simply prepending a path to the right hand side of the mix-manifest file.

e.g.
> "/js/jquery.min.js": "/js/jquery.min.js?id=220afd743d9e9643852e", 

should read

> "/js/jquery.min.js": "/blog/js/jquery.min.js?id=220afd743d9e9643852e", 

Using the code in the pull request setting the new config option is as simple as
``mix.setRootSubdirectory('blog'); 

I think this would be useful to anyone running Laravel in a subdirectory on their web server or development environments.