### PR TITLE
use fs.mkdirSync instead of fs-extra.ensureDirSync

### DIFF
--- a/src/File.js
+++ b/src/File.js
@@ -177,7 +177,7 @@ class File {
      * Create all nested directories.
      */
     makeDirectories() {
-        fs.ensureDirSync(this.base());
+        fs.mkdirSync(this.base(), {recursive: true});
 
         return this;
     }


### PR DESCRIPTION
- node.js fs.mkdirSync can make directories recursively since 10.12.0
    - [node/CHANGELOG_V10.md at master · nodejs/node](https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V10.md#2018-10-10-version-10120-current-targos)
    - [File System | Node.js v12.2.0 Documentation](https://nodejs.org/api/fs.html#fs_fs_mkdirsync_path_options)
- fs-extra.mkdirp/mkdirs/ensureDir may be removed.
    - [Recursive mkdir coming to Node core · Issue #619 · jprichardson/node-fs-extra](https://github.com/jprichardson/node-fs-extra/issues/619)