### PR TITLE
Cross-platform yarn detection

### DIFF
--- a/src/Dependencies.js
+++ b/src/Dependencies.js
@@ -71,7 +71,7 @@ class Dependencies {
 
         if (!forceNpm) {
             try {
-                childProcess.execSync('command -v yarn >/dev/null');
+                childProcess.execSync('yarn -v');
 
                 return `yarn add ${dependencies} --dev --production=false`;
             } catch (e) {}


### PR DESCRIPTION
`command -v yarn >/dev/null` works only on Unix systems.
What about just to execute yarn itself to detect its presence?