### PR TITLE
Replace extract-text-webpack-plugin with mini-css-extract-plugin

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -7188,8 +7188,7 @@
         "is-plain-obj": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-            "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
-            "dev": true
+            "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
         },
         "is-plain-object": {
             "version": "2.0.4",
@@ -8109,6 +8108,30 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
             "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
+        },
+        "mini-css-extract-plugin": {
+            "version": "0.7.0",
+            "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-0.7.0.tgz",
+            "integrity": "sha512-RQIw6+7utTYn8DBGsf/LpRgZCJMpZt+kuawJ/fju0KiOL6nAaTBNmCJwS7HtwSCXfS47gCkmtBFS7HdsquhdxQ==",
+            "requires": {
+                "loader-utils": "^1.1.0",
+                "normalize-url": "1.9.1",
+                "schema-utils": "^1.0.0",
+                "webpack-sources": "^1.1.0"
+            },
+            "dependencies": {
+                "normalize-url": {
+                    "version": "1.9.1",
+                    "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-1.9.1.tgz",
+                    "integrity": "sha1-LMDWazHqIwNkWENuNiDYWVTGbDw=",
+                    "requires": {
+                        "object-assign": "^4.0.1",
+                        "prepend-http": "^1.0.0",
+                        "query-string": "^4.1.0",
+                        "sort-keys": "^1.0.0"
+                    }
+                }
+            }
         },
         "minimalistic-assert": {
             "version": "1.0.1",
@@ -9845,8 +9868,7 @@
         "prepend-http": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
-            "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
-            "dev": true
+            "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="
         },
         "prettier": {
             "version": "1.15.2",
@@ -10192,6 +10214,15 @@
             "version": "6.5.2",
             "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
             "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+        },
+        "query-string": {
+            "version": "4.3.4",
+            "resolved": "https://registry.npmjs.org/query-string/-/query-string-4.3.4.tgz",
+            "integrity": "sha1-u7aTucqRXCMlFbIosaArYJBD2+s=",
+            "requires": {
+                "object-assign": "^4.1.0",
+                "strict-uri-encode": "^1.0.0"
+            }
         },
         "querystring": {
             "version": "0.2.0",
@@ -11180,6 +11211,14 @@
                 }
             }
         },
+        "sort-keys": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
+            "integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
+            "requires": {
+                "is-plain-obj": "^1.0.0"
+            }
+        },
         "source-list-map": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.1.tgz",
@@ -11441,6 +11480,11 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
             "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI="
+        },
+        "strict-uri-encode": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
+            "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM="
         },
         "string-width": {
             "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
     ],
     "dependencies": {
         "@babel/core": "^7.2.0",
-        "@babel/plugin-syntax-dynamic-import": "^7.2.0",
         "@babel/plugin-proposal-object-rest-spread": "^7.2.0",
+        "@babel/plugin-syntax-dynamic-import": "^7.2.0",
         "@babel/plugin-transform-runtime": "^7.2.0",
         "@babel/preset-env": "^7.2.0",
         "@babel/runtime": "^7.2.0",
@@ -55,6 +55,7 @@
         "img-loader": "^3.0.0",
         "lodash": "^4.17.5",
         "md5": "^2.2.1",
+        "mini-css-extract-plugin": "^0.7.0",
         "optimize-css-assets-webpack-plugin": "^5.0.1",
         "postcss-loader": "^3.0.0",
         "style-loader": "^0.23.1",

--- a/src/builder/webpack-default.js
+++ b/src/builder/webpack-default.js
@@ -2,6 +2,19 @@ let TerserPlugin = require('terser-webpack-plugin');
 let OptimizeCSSAssetsPlugin = require('optimize-css-assets-webpack-plugin');
 
 module.exports = function() {
+    const optimization = Mix.inProduction()
+        ? {
+              minimizer: [
+                  new TerserPlugin(Config.terser),
+                  new OptimizeCSSAssetsPlugin({
+                      cssProcessorPluginOptions: {
+                          preset: ['default', Config.cssNano]
+                      }
+                  })
+              ]
+          }
+        : {};
+
     return {
         context: Mix.paths.root(),
 
@@ -37,18 +50,17 @@ module.exports = function() {
             hints: false
         },
 
-        optimization: Mix.inProduction()
-            ? {
-                  minimizer: [
-                      new TerserPlugin(Config.terser),
-                      new OptimizeCSSAssetsPlugin({
-                          cssProcessorPluginOptions: {
-                              preset: ['default', Config.cssNano]
-                          }
-                      })
-                  ]
-              }
-            : {},
+        optimization: {
+            ...optimization,
+            namedModules: true,
+            namedChunks: true,
+            splitChunks: {
+                minChunks: 1,
+                cacheGroups: {
+                    default: false
+                }
+            }
+        },
 
         devtool: Config.sourcemaps,
 

--- a/src/components/Vue.js
+++ b/src/components/Vue.js
@@ -1,5 +1,5 @@
 let { VueLoaderPlugin } = require('vue-loader');
-let ExtractTextPlugin = require('extract-text-webpack-plugin');
+let MiniCssExtractPlugin = require('mini-css-extract-plugin');
 let { without } = require('lodash');
 
 class Vue {
@@ -94,10 +94,10 @@ class Vue {
         if (Config.extractVueStyles) {
             let extractPlugin = this.extractPlugin();
 
-            rule.loaders = extractPlugin.extract({
-                fallback: 'style-loader',
-                use: without(rule.loaders, 'style-loader')
-            });
+            rule.loaders = [
+                MiniCssExtractPlugin.loader,
+                ...without(rule.loaders, 'style-loader')
+            ];
 
             this.addExtractPluginToConfig(extractPlugin, webpackConfig);
         }
@@ -158,7 +158,9 @@ class Vue {
 
         // Otherwise, we'll need to whip up a fresh extract text instance.
         return tap(
-            new ExtractTextPlugin(this.extractFileName()),
+            new MiniCssExtractPlugin({
+                filename: this.extractFileName()
+            }),
             extractPlugin => {
                 extractPlugin.isNew = true;
             }

--- a/test/features/vue.js
+++ b/test/features/vue.js
@@ -15,18 +15,18 @@ test.serial.cb('it appends vue styles to your sass compiled file', t => {
         t.true(File.exists('test/fixtures/fake-app/public/js/app.js'));
         t.true(File.exists('test/fixtures/fake-app/public/css/app.css'));
 
-        let expected = `body {
-  color: red;
-}
-
-
-.hello {
+        let expected = `.hello {
   color: blue;
+}
+body {
+  color: red;
 }`;
 
         t.is(
-            expected,
-            File.find('test/fixtures/fake-app/public/css/app.css').read()
+            expected.trim(),
+            File.find('test/fixtures/fake-app/public/css/app.css')
+                .read()
+                .trim()
         );
     });
 });
@@ -46,17 +46,18 @@ test.serial.cb('it prepends vue styles to your less compiled file', t => {
         t.true(File.exists('test/fixtures/fake-app/public/js/app.js'));
         t.true(File.exists('test/fixtures/fake-app/public/css/app.css'));
 
-        let expected = `body {
-  color: pink;
-}
-
-.hello {
+        let expected = `.hello {
   color: blue;
+}
+body {
+  color: pink;
 }`;
 
         t.is(
-            expected,
-            File.find('test/fixtures/fake-app/public/css/app.css').read()
+            expected.trim(),
+            File.find('test/fixtures/fake-app/public/css/app.css')
+                .read()
+                .trim()
         );
     });
 });
@@ -75,16 +76,15 @@ test.serial.cb(
                 File.exists('test/fixtures/fake-app/public/css/vue-styles.css')
             );
 
-            let expected = `
-.hello {
+            let expected = `.hello {
   color: blue;
 }`;
 
             t.is(
-                expected,
-                File.find(
-                    'test/fixtures/fake-app/public/css/vue-styles.css'
-                ).read()
+                expected.trim(),
+                File.find('test/fixtures/fake-app/public/css/vue-styles.css')
+                    .read()
+                    .trim()
             );
         });
     }
@@ -99,15 +99,15 @@ test.serial.cb('it extracts vue vanilla CSS styles to a dedicated file', t => {
     compile(t, config => {
         t.true(File.exists('test/fixtures/fake-app/public/css/components.css'));
 
-        let expected = `
-.hello {
+        let expected = `.hello {
     color: green;
-}
-`;
+}`;
 
         t.is(
-            expected,
-            File.find('test/fixtures/fake-app/public/css/components.css').read()
+            expected.trim(),
+            File.find('test/fixtures/fake-app/public/css/components.css')
+                .read()
+                .trim()
         );
     });
 });
@@ -121,15 +121,15 @@ test.serial.cb('it extracts vue Stylus styles to a dedicated file', t => {
     compile(t, config => {
         t.true(File.exists('test/fixtures/fake-app/public/css/components.css'));
 
-        let expected = `
-.hello {
+        let expected = `.hello {
   margin: 10px;
-}
-`;
+}`;
 
         t.is(
-            expected,
-            File.find('test/fixtures/fake-app/public/css/components.css').read()
+            expected.trim(),
+            File.find('test/fixtures/fake-app/public/css/components.css')
+                .read()
+                .trim()
         );
     });
 });
@@ -165,23 +165,24 @@ test.serial.cb('it extracts vue .scss styles to a dedicated file', t => {
 
         let expected = `body {
   color: red;
-}
-
-`;
+}`;
 
         t.is(
-            expected,
-            File.find('test/fixtures/fake-app/public/css/app.css').read()
+            expected.trim(),
+            File.find('test/fixtures/fake-app/public/css/app.css')
+                .read()
+                .trim()
         );
 
-        expected = `
-.hello {
+        expected = `.hello {
   color: blue;
 }`;
 
         t.is(
-            expected,
-            File.find('test/fixtures/fake-app/public/css/components.css').read()
+            expected.trim(),
+            File.find('test/fixtures/fake-app/public/css/components.css')
+                .read()
+                .trim()
         );
     });
 });
@@ -204,23 +205,24 @@ test.serial.cb('it extracts vue .sass styles to a dedicated file', t => {
 
         let expected = `body {
   color: red;
-}
-
-`;
+}`;
 
         t.is(
-            expected,
-            File.find('test/fixtures/fake-app/public/css/app.css').read()
+            expected.trim(),
+            File.find('test/fixtures/fake-app/public/css/app.css')
+                .read()
+                .trim()
         );
 
-        expected = `
-.hello {
+        expected = `.hello {
   color: black;
 }`;
 
         t.is(
-            expected,
-            File.find('test/fixtures/fake-app/public/css/components.css').read()
+            expected.trim(),
+            File.find('test/fixtures/fake-app/public/css/components.css')
+                .read()
+                .trim()
         );
     });
 });
@@ -233,19 +235,19 @@ test.serial.cb('it extracts vue PostCSS styles to a dedicated file', t => {
 
     compile(t, config => {
         // In this example, postcss-loader is reading from postcss.config.js.
-        let expected = `
-:root {
+        let expected = `:root {
     --color: white;
 }
 .hello {
     color: white;
     color: var(--color);
-}
-`;
+}`;
 
         t.is(
-            expected,
-            File.find('test/fixtures/fake-app/public/css/components.css').read()
+            expected.trim(),
+            File.find('test/fixtures/fake-app/public/css/components.css')
+                .read()
+                .trim()
         );
     });
 });
@@ -259,15 +261,15 @@ test.serial.cb('it extracts vue Less styles to a dedicated file', t => {
     compile(t, config => {
         t.true(File.exists('test/fixtures/fake-app/public/css/components.css'));
 
-        let expected = `
-.hello {
+        let expected = `.hello {
   color: blue;
-}
-`;
+}`;
 
         t.is(
-            expected,
-            File.find('test/fixtures/fake-app/public/css/components.css').read()
+            expected.trim(),
+            File.find('test/fixtures/fake-app/public/css/components.css')
+                .read()
+                .trim()
         );
     });
 });


### PR DESCRIPTION
extract-text-webpack-plugin depracted, alpha version is not stable with webpack v4

This PR resolve some issues with CSS while using dynamic import or extractVueStyles

https://github.com/JeffreyWay/laravel-mix/issues/1954
https://github.com/JeffreyWay/laravel-mix/issues/2126