### PR TITLE
Add vueTemplateCompiler option to Mix

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -3,6 +3,7 @@
 ```js
 mix.options({
     extractVueStyles: false,
+    vueTemplateCompiler: false,
     processCssUrls: true,
     terser: {},
     purifyCss: false,
@@ -18,6 +19,7 @@ mix.options({
 A handful of Mix options and overrides are available, should you require them. Please take note of the options above, as well as their default values. Here's a quick overview:
 
 -   **extractVueStyles:** Extract `.vue` component styling (CSS within `<style>` tags) to a dedicated file, rather than inlining it into the HTML.
+-   **vueTemplateCompiler:** Control whether you would like to have vue-template-compiler installed as a dependency for non-Vue JavaScript apps. Set it to false, if you don't want it installed.
 -   **globalVueStyles:** Indicate a file to include in every component styles. This file should only include variables, functions or mixins in order to prevent duplicated css in your final, compiled files. This option only works when `extractVueStyles` is enabled.
 -   **processCssUrls:** Process/optimize relative stylesheet url()'s. By default, Webpack will automatically update these URLs, when relevant. If, however, your folder structure is already organized the way you want it, set this option to `false` to disable processing.
 -   **terser:** Use this option to merge any [custom Terser options](https://github.com/webpack-contrib/terser-webpack-plugin#options) that your project requires.

--- a/setup/webpack.mix.js
+++ b/setup/webpack.mix.js
@@ -44,6 +44,7 @@ mix.js('src/app.js', 'dist/').sass('src/app.scss', 'dist/');
 // mix.options({
 //   extractVueStyles: false, // Extract .vue component styling to file, rather than inline.
 //   globalVueStyles: file, // Variables file to be imported in every component.
+//   vueTemplateCompiler: false, // Install vue-template-compiler in non-Vue apps. Set it to false , if you don't want it.
 //   processCssUrls: true, // Process/optimize relative stylesheet url()'s. Set to false, if you don't want them touched.
 //   purifyCss: false, // Remove unused CSS selectors.
 //   terser: {}, // Terser-specific options. https://github.com/webpack-contrib/terser-webpack-plugin#options

--- a/src/components/Vue.js
+++ b/src/components/Vue.js
@@ -7,7 +7,10 @@ class Vue {
      * Required dependencies for the component.
      */
     dependencies() {
-        let dependencies = ['vue-template-compiler'];
+
+        if (Config.vueTemplateCompiler) {
+            let dependencies = ['vue-template-compiler'];
+        }
 
         if (Config.extractVueStyles && Config.globalVueStyles) {
             dependencies.push('sass-resources-loader');

--- a/src/components/Vue.js
+++ b/src/components/Vue.js
@@ -7,9 +7,10 @@ class Vue {
      * Required dependencies for the component.
      */
     dependencies() {
+        let dependencies = [];
 
         if (Config.vueTemplateCompiler) {
-            let dependencies = ['vue-template-compiler'];
+            dependencies.push('vue-template-compiler');
         }
 
         if (Config.extractVueStyles && Config.globalVueStyles) {

--- a/src/config.js
+++ b/src/config.js
@@ -144,6 +144,17 @@ module.exports = function() {
         extractVueStyles: false,
 
         /**
+         * Should we install vue-template-compiler for non-Vue JavaScript?
+         * Set it to false, if you would like to disable installing it as
+         * a dependency.
+         *
+         * Ex: vueTemplateCompiler: false
+         *
+         * @type {Boolean}
+         */
+        vueTemplateCompiler: true,
+        
+        /**
          * A file path with global styles that should be imported into every Vue component.
          *
          * See: https://vue-loader.vuejs.org/en/configurations/pre-processors.html#loading-a-global-settings-file


### PR DESCRIPTION
Hey @JeffreyWay,

I am submitting a pull request that addresses the installation of vue-template-compiler as a dependency in non-Vue JavaScript apps. By default, I have set it to true by default, therefore it is not a breaking change for old projects.

The issue has been referenced in issue #1877 as well as causing unwanted behavior in the Laravel presets (see the pull request [here](https://github.com/laravel/framework/pull/28389)).

Additionally, it gives the Laravel Mix extension developers control over installing the vue-template-compiler dependency in their extensions. As an extension author, I would very much like to have this control in my [mix.svelte()](https://github.com/wewowweb/laravel-mix-svelte) extension.

Hope you find the changes reasonable and would be willing to merge them into master.

Kind regards,
g