### PR TITLE
Allow chaining Mix.override

### DIFF
--- a/src/Api.js
+++ b/src/Api.js
@@ -103,6 +103,8 @@ class Api {
      */
     override(callback) {
         Mix.listen('configReadyForUser', callback);
+
+        return this;
     }
 
     /**


### PR DESCRIPTION
I assume this was simply overlooked, unless there's a specific reason why we don't want this to be chainable?