### PR TITLE
Ignore node_modules on the watcher by default

### DIFF
--- a/src/builder/webpack-default.js
+++ b/src/builder/webpack-default.js
@@ -61,6 +61,10 @@ module.exports = function() {
             noInfo: true,
             compress: true,
             quiet: true
+        },
+        
+        watchOptions: {
+            ignored: /node_modules/
         }
     };
 };


### PR DESCRIPTION
See [this tweet](https://twitter.com/stidges/status/1148560869913178112) and [Jeffrey's response](https://twitter.com/jeffrey_way/status/1150856921920004096).