### PR TITLE
Make the notification timeout configurable and unset by default

### DIFF
--- a/docs/os-notifications.md
+++ b/docs/os-notifications.md
@@ -7,3 +7,11 @@ mix.js(src, output).disableNotifications();
 ```
 
 Simple!
+
+You can set the timeout for the notifications with the following:
+
+```js
+mix.setNotificationsTimeout(2);
+```
+
+This would set the notifications timeout to 2 seconds but you may have to use milliseconds based on your OS.

--- a/setup/webpack.mix.js
+++ b/setup/webpack.mix.js
@@ -33,6 +33,7 @@ mix.js('src/app.js', 'dist/').sass('src/app.scss', 'dist/');
 // mix.sourceMaps(); // Enable sourcemaps
 // mix.version(); // Enable versioning.
 // mix.disableNotifications();
+// mix.setNotificationsTimeout(timeout);
 // mix.setPublicPath('path/to/public');
 // mix.setResourceRoot('prefix/for/resource/locators');
 // mix.autoload({}); <-- Will be passed to Webpack's ProvidePlugin.

--- a/src/components/ComponentFactory.js
+++ b/src/components/ComponentFactory.js
@@ -22,6 +22,7 @@ let components = [
     'Extract',
     'Notifications',
     'DisableNotifications',
+    'NotificationsTimeout',
     'PurifyCss',
     'DumpWebpackConfig'
 ];

--- a/src/components/DisableNotifications.js
+++ b/src/components/DisableNotifications.js
@@ -11,10 +11,8 @@ class DisableNotifications {
      */
     register() {
         if (this.caller === 'disableSuccessNotifications') {
-            Config.notifications = {
-                onSuccess: false,
-                onFailure: true
-            };
+            Config.notifications.onSuccess = false;
+            Config.notifications.onFailure = true;
         } else {
             Config.notifications = false;
         }

--- a/src/components/Notifications.js
+++ b/src/components/Notifications.js
@@ -15,7 +15,7 @@ class Notifications extends AutomaticComponent {
                     process.platform === 'linux'
                         ? 'int:transient:1'
                         : undefined,
-		timeout: 2,
+                timeout: Config.notifications.timeout,
                 contentImage: Mix.paths.root(
                     'node_modules/laravel-mix/icons/laravel.png'
                 )

--- a/src/components/NotificationsTimeout.js
+++ b/src/components/NotificationsTimeout.js
@@ -1,0 +1,18 @@
+class NotificationsTimeout {
+    /**
+     * The API name for the component.
+     */
+    name() {
+        return ['setNotificationsTimeout'];
+    }
+
+    /**
+     * Register the component.
+     *  @param {int} timeout
+     */
+    register(timeout) {
+        Config.notifications.timeout = timeout;
+    }
+}
+
+module.exports = NotificationsTimeout;

--- a/src/config.js
+++ b/src/config.js
@@ -69,7 +69,8 @@ module.exports = function() {
          */
         notifications: {
             onSuccess: true,
-            onFailure: true
+            onFailure: true,
+            timeout: undefined
         },
 
         /**

--- a/test/features/notifications.js
+++ b/test/features/notifications.js
@@ -42,3 +42,18 @@ test.cb('it disables OS success notifications', t => {
 test('mix.disableNotifications()', t => {
     t.is(mix, mix.disableNotifications());
 });
+
+test.cb('it set OS notifications timeout', t => {
+    let timeout = 2;
+    mix.setNotificationsTimeout(timeout);
+
+    compile(t, config => {
+        // Find the webpack-notifier plugin. (Yeah, a little awkward...)
+        let plugin = config.plugins.find(
+            // Check the plugin timeout option
+            plugin => plugin.options && plugin.options.timeout === timeout
+        );
+
+        t.truthy(plugin);
+    });
+});


### PR DESCRIPTION
KDE Plasma's notification timeout is set in milliseconds, not seconds.

This causes the hardcoded timeout of 2 to be interpreted as 2ms instead of 2 seconds and causes the notification to be unreadable.

Since the 2 is not a value working universally, I propose to make the timeout configurable and set it to undefined by default. On most desktop environments this seems to be 5 seconds. If this is too high for some users, they can either:
- Rely on their desktop environment to configure the timeout
- Set it themselves in Mix's config

Fixes https://github.com/JeffreyWay/laravel-mix/issues/2161