### PR TITLE
Use repo level postcss config if no custom config

### DIFF
--- a/src/components/Css.js
+++ b/src/components/Css.js
@@ -106,7 +106,7 @@ class Css extends AutomaticComponent {
      * Fetch the appropriate postcss plugins for the compile.
      */
     postCssOptions() {
-        if (Mix.components.get('postCss')) {
+        if (Mix.components.get('postCss') && Mix.components.get('postCss').details[0].postCssPlugins.length) {
             return {
                 plugins: Mix.components.get('postCss').details[0].postCssPlugins
             };


### PR DESCRIPTION
Use `postcss.config.js` if the config file is present **and** `Mix.components.get('postCss').details[0].postCssPlugins` is empty.

May help to resolve: #1979