### PR TITLE
Update Browsersync snippet regex to use a lookbehind

### DIFF
--- a/src/components/Browsersync.js
+++ b/src/components/Browsersync.js
@@ -35,6 +35,14 @@ class Browsersync {
     }
 
     /**
+     * The regex used to determine where the Browsersync
+     * javascript snippet is injected onto each page.
+     */
+    regex() {
+        return RegExp('(</body>|</pre>)(?!.*(</body>|</pre>))', 'is');
+    }
+
+    /**
      * Build the BrowserSync configuration.
      */
     config() {
@@ -50,7 +58,7 @@ class Browsersync {
                 ],
                 snippetOptions: {
                     rule: {
-                        match: /(<\/body>|<\/pre>)/i,
+                        match: this.regex(),
                         fn: function(snippet, match) {
                             return snippet + match;
                         }

--- a/test/features/browsersync.js
+++ b/test/features/browsersync.js
@@ -1,5 +1,6 @@
 import mix from './helpers/setup';
 import mockRequire from 'mock-require';
+import Browsersync from '../../src/components/Browsersync';
 
 mockRequire(
     'browser-sync-webpack-plugin',
@@ -20,4 +21,24 @@ test.serial.cb('it handles Browsersync reloading', t => {
             )
         );
     });
+});
+
+test.serial.cb('it injects the snippet in the right place', t => {
+    let regex = new Browsersync().regex();
+
+    t.is(regex.exec(`<div></div>`), null);
+    t.is(regex.exec(`<body></body>`).index, 6);
+    t.is(regex.exec(`<BODY></BODY>`).index, 6);
+    t.is(regex.exec(`<pre></pre>`).index, 5);
+    t.is(regex.exec(`<body><pre></pre></body>`).index, 17);
+    t.is(
+        regex.exec(`
+            <body>
+                <pre></pre>
+                <div></div>
+                <pre></pre>
+            </body>
+        `).index,
+        116
+    );
 });


### PR DESCRIPTION
The current regex is `/(<\/body>|<\/pre>)/i` so it will find either the **first** `</body>` or `</pre>` tag, but it should really find the **last**.

This PR adds a lookbehind to the regex to grab the last one instead.

This would be the effect of this change on a page that contains a `</pre>` _and_ a `</body>`:

```diff
<html>
<body>
    <pre>
--        <script src="browsersync.js"></script>
    </pre>
++  <script src="browsersync.js"></script>
</body>
</html>
```

Fixes #2239
Fixes laravel/framework#29909
Fixes laravel/framework#30018
Fixes facade/ignition#16
Fixes BrowserSync/browser-sync#1459