### PR TITLE
Node-sass, Dart-sass conflict issue on component

### DIFF
--- a/src/components/Vue.js
+++ b/src/components/Vue.js
@@ -55,11 +55,12 @@ class Vue {
 
         // SASS
         let sassCallback = rule => {
-            if (Mix.seesNpmPackage('sass')) {
+            if (Mix.seesNpmPackage('sass')) { // would be better if it's support regex
                 rule.loaders.find(
                     loader => loader.loader === 'sass-loader'
-                ).options.implementation = require('sass');
+                ).options.implementation = Config.componentStylesCompiler ? Config.componentStylesCompiler : require('sass');
             }
+
 
             if (Config.globalVueStyles) {
                 rule.loaders.push({


### PR DESCRIPTION
Hello ,
Let me get into the heart of the subject
am use two Vue projects in the same Laravel project, the first one built with element ui (use node-sass as sass compiler) and have deep selectors ,the second which should be built in Vuetify (use dart-sass ) The problem appeared when i tried to build the second many errors shown ,I decided to find the reason and discovered that is issue happen when mix try to compile styles inside vue component ,so i made some changes to some mix source files, hope to reviews it and tell me if what i did is wrong

- in src/components/Vue.js
   ` if (Mix.seesNpmPackage('sass')) { // would be better if it's support regex rule.loaders.find( loader => loader.loader === 'sass-loader' ).options.implementation = Config.componentStylesCompiler ? Config.componentStylesCompiler : require('sass'); }
`
- webpack file
   ` mix .setPublicPath(path.normalize('public/dashboard/')) .js('resources/frontends/admin/app.js', 'js/app.js') .extract([ 'vue', 'axios', 'vuex', 'vue-router', 'vue-i18n', 'element-ui', 'echarts', 'highlight.js', 'sortablejs', 'dropzone', 'xlsx', 'tui-editor', 'codemirror', ]) .options({ processCssUrls: false, componentStylesCompiler : require('node-sass') })`
   
all work great with me,
