### PR TITLE
node-sass, dart-sass compile issue

### DIFF
--- a/src/components/Vue.js
+++ b/src/components/Vue.js
@@ -59,7 +59,7 @@ class Vue {
                 ? Config.componentStylesCompiler
                 : Mix.seesNpmPackage('sass')
                 ? 'sass'
-                : false;
+                : false; //Select sass compiler
             if (compiler) {
                 rule.loaders.find(
                     loader => loader.loader === 'sass-loader'

--- a/src/components/Vue.js
+++ b/src/components/Vue.js
@@ -55,10 +55,15 @@ class Vue {
 
         // SASS
         let sassCallback = rule => {
-            if (Mix.seesNpmPackage('sass')) {
+            const compiler = Mix.seesNpmPackage(Config.componentStylesCompiler)
+                ? Config.componentStylesCompiler
+                : Mix.seesNpmPackage('sass')
+                ? 'sass'
+                : false;
+            if (compiler) {
                 rule.loaders.find(
                     loader => loader.loader === 'sass-loader'
-                ).options.implementation = require('sass');
+                ).options.implementation = require(compiler);
             }
 
             if (Config.globalVueStyles) {

--- a/test/features/vue.js
+++ b/test/features/vue.js
@@ -9,7 +9,10 @@ test.serial.cb('it appends vue styles to your sass compiled file', t => {
             'test/fixtures/fake-app/resources/assets/sass/app.scss',
             'css/app.css'
         )
-        .options({ extractVueStyles: true });
+        .options({
+            extractVueStyles: true,
+            componentStylesCompiler: 'node-sass'
+        });
 
     compile(t, () => {
         t.true(File.exists('test/fixtures/fake-app/public/js/app.js'));


### PR DESCRIPTION
Hello ,
Let me get into the heart of the subject
am use two Vue projects in the same Laravel project, the first one built with element ui (use node-sass as sass compiler) and have deep selectors ,the second which should be built in Vuetify (use dart-sass ) The problem appeared when i tried to build the second many errors shown ,I decided to find the reason and discovered that is issue happen when mix try to compile styles inside vue component ,so i made some changes to some mix source files, hope to reviews it and tell me if what i did is wrong

- in src/components/Vue.js
```
const compiler = Mix.seesNpmPackage(Config.componentStylesCompiler)
                ? Config.componentStylesCompiler
                : Mix.seesNpmPackage('sass')
                ? 'sass'
                : false;
            if (compiler) {
                rule.loaders.find(
                    loader => loader.loader === 'sass-loader'
                ).options.implementation = require(compiler);
            }
```

- test/vue.js file
```
    mix.js(
        'test/fixtures/fake-app/resources/assets/vue/app-with-vue-and-scss.js',
        'js/app.js'
    )
        .sass(
            'test/fixtures/fake-app/resources/assets/sass/app.scss',
            'css/app.css'
        )
        .options({
            extractVueStyles: true,
            componentStylesCompiler: 'node-sass'
        });
```
    
all work great with me
