### PR TITLE
Fix prod css/sass sourcemaps (#1793)

### DIFF
--- a/src/builder/webpack-default.js
+++ b/src/builder/webpack-default.js
@@ -39,14 +39,7 @@ module.exports = function() {
 
         optimization: Mix.inProduction()
             ? {
-                  minimizer: [
-                      new TerserPlugin(Config.terser),
-                      new OptimizeCSSAssetsPlugin({
-                          cssProcessorPluginOptions: {
-                              preset: ['default', Config.cssNano]
-                          }
-                      })
-                  ]
+                  minimizer: [new TerserPlugin(Config.terser)]
               }
             : {},
 

--- a/src/components/Preprocessor.js
+++ b/src/components/Preprocessor.js
@@ -69,7 +69,6 @@ class Preprocessor {
                                     plugins.push(
                                         require('cssnano')({
                                             preset: ['default', Config.cssNano]
-                                            // preset: 'default'
                                         })
                                     );
                                 }

--- a/src/components/Preprocessor.js
+++ b/src/components/Preprocessor.js
@@ -65,6 +65,12 @@ class Preprocessor {
                                     );
                                 }
 
+                                if (Mix.inProduction()) {
+                                    require('cssnano')({
+                                        preset: 'default'
+                                    });
+                                }
+
                                 return plugins;
                             })()
                         }

--- a/src/components/Preprocessor.js
+++ b/src/components/Preprocessor.js
@@ -68,7 +68,8 @@ class Preprocessor {
                                 if (Mix.inProduction()) {
                                     plugins.push(
                                         require('cssnano')({
-                                            preset: 'default'
+                                            preset: ['default', Config.cssNano]
+                                            // preset: 'default'
                                         })
                                     );
                                 }

--- a/src/components/Preprocessor.js
+++ b/src/components/Preprocessor.js
@@ -66,9 +66,11 @@ class Preprocessor {
                                 }
 
                                 if (Mix.inProduction()) {
-                                    require('cssnano')({
-                                        preset: 'default'
-                                    });
+                                    plugins.push(
+                                        require('cssnano')({
+                                            preset: 'default'
+                                        })
+                                    );
                                 }
 
                                 return plugins;


### PR DESCRIPTION
See Issue #1793

Sass sourcemaps fail to generate in production builds due to cssnano
combined with OptimizeCSSAssetsPlugin.  Moving cssnano into
postcss-loader resolves issue.

More detail https://www.webfoobar.com/node/109

Note eval-source-maps still will not work at all for CSS, so
implementers must use `Mix.sourceMaps(true, 'source-map')` to allow
development builds to successfully generate sourcemaps.