### PR TITLE
Pass options to ts-loader using a third argument

### DIFF
--- a/src/components/TypeScript.js
+++ b/src/components/TypeScript.js
@@ -40,10 +40,11 @@ class TypeScript extends JavaScript {
             test: /\.tsx?$/,
             loader: 'ts-loader',
             exclude: /node_modules/,
-            options: {
-                appendTsSuffixTo: [/\.vue$/],
-                ...this.options
-            }
+            options: Object.assign(
+                {},
+                { appendTsSuffixTo: [/\.vue$/] },
+                this.options
+            )
         });
     }
 

--- a/src/components/TypeScript.js
+++ b/src/components/TypeScript.js
@@ -1,11 +1,28 @@
 let JavaScript = require('./JavaScript');
 
 class TypeScript extends JavaScript {
+    constructor() {
+        super();
+        this.options = {};
+    }
+
     /**
      * The API name for the component.
      */
     name() {
         return ['typeScript', 'ts'];
+    }
+
+    /**
+     * Register the component.
+     *
+     * @param {*} entry
+     * @param {string} output
+     * @param {object} options
+     */
+    register(entry, output, options = {}) {
+        super.register(entry, output);
+        this.options = options;
     }
 
     /**
@@ -24,7 +41,8 @@ class TypeScript extends JavaScript {
             loader: 'ts-loader',
             exclude: /node_modules/,
             options: {
-                appendTsSuffixTo: [/\.vue$/]
+                appendTsSuffixTo: [/\.vue$/],
+                ...this.options
             }
         });
     }

--- a/test/features/typescript.js
+++ b/test/features/typescript.js
@@ -45,3 +45,12 @@ test.serial('it applies the correct webpack rules', t => {
         )
     );
 });
+
+test.serial('it is able to apply options to ts-loader', t => {
+    mix.ts('resources/assets/js/app.js', 'public/js', { transpileOnly: true });
+
+    t.truthy(
+        buildConfig().module.rules.find(rule => rule.loader === 'ts-loader')
+            .options.transpileOnly
+    );
+});


### PR DESCRIPTION
This pull request makes it possible to pass a third argument to ts-loader, for example:

```js
.ts('resources/ts/app.ts', 'public/js', { transpileOnly: !mix.inProduction() })
```