### PR TITLE
adds optional --hmr-port argument (#2308)

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -1,3 +1,5 @@
+const argv = require('yargs').argv;
+
 module.exports = function() {
     return {
         /**
@@ -23,7 +25,7 @@ module.exports = function() {
          */
         hmrOptions: {
             host: 'localhost',
-            port: '8080'
+            port: !!argv.hmrPort ? argv.hmrPort : '8080'
         },
 
         /**


### PR DESCRIPTION
Now you can run a command:
npm run hot -- --hmr-port=8081

So webpack's output port is changable and won't cause port problems, see issue #2308