### PR TITLE
Use sync test instead of callback

### DIFF
--- a/test/features/browsersync.js
+++ b/test/features/browsersync.js
@@ -23,7 +23,7 @@ test.serial.cb('it handles Browsersync reloading', t => {
     });
 });
 
-test.serial.cb('it injects the snippet in the right place', t => {
+test.serial('it injects the snippet in the right place', t => {
     let regex = new Browsersync().regex();
 
     t.is(regex.exec(`<div></div>`), null);


### PR DESCRIPTION
The `browsersync` feature test `it injects the snippet in the right place` was failing because it expected the test to be manually ended through `t.end()`, which was not necessary since everything is sync in this test.