### PR TITLE
Expose css-loader modules option

### DIFF
--- a/src/components/Css.js
+++ b/src/components/Css.js
@@ -10,7 +10,7 @@ class Css extends AutomaticComponent {
                 test: /\.css$/,
                 loaders: [
                     'style-loader',
-                    { loader: 'css-loader', options: { importLoaders: 1 } },
+                    { loader: 'css-loader', options: { importLoaders: 1, modules: Config.enableCssModules } },
                     {
                         loader: 'postcss-loader',
                         options: this.postCssOptions()
@@ -23,7 +23,7 @@ class Css extends AutomaticComponent {
                 exclude: this.excludePathsFor('sass'),
                 loaders: [
                     'style-loader',
-                    'css-loader',
+                    { loader: 'css-loader', options: { modules: Config.enableCssModules } },
                     {
                         loader: 'postcss-loader',
                         options: this.postCssOptions()
@@ -45,7 +45,7 @@ class Css extends AutomaticComponent {
                 exclude: this.excludePathsFor('sass'),
                 loaders: [
                     'style-loader',
-                    'css-loader',
+                    { loader: 'css-loader', options: { modules: Config.enableCssModules } },
                     {
                         loader: 'postcss-loader',
                         options: this.postCssOptions()
@@ -68,7 +68,7 @@ class Css extends AutomaticComponent {
                 exclude: this.excludePathsFor('less'),
                 loaders: [
                     'style-loader',
-                    'css-loader',
+                    { loader: 'css-loader', options: { modules: Config.enableCssModules } },
                     {
                         loader: 'postcss-loader',
                         options: this.postCssOptions()
@@ -82,7 +82,7 @@ class Css extends AutomaticComponent {
                 exclude: this.excludePathsFor('stylus'),
                 loaders: [
                     'style-loader',
-                    'css-loader',
+                    { loader: 'css-loader', options: { modules: Config.enableCssModules } },
                     {
                         loader: 'postcss-loader',
                         options: this.postCssOptions()

--- a/src/components/Css.js
+++ b/src/components/Css.js
@@ -8,12 +8,53 @@ class Css extends AutomaticComponent {
         return [
             {
                 test: /\.css$/,
-                loaders: [
-                    'style-loader',
-                    { loader: 'css-loader', options: { importLoaders: 1, modules: Config.enableCssModules } },
+                oneOf: [
                     {
-                        loader: 'postcss-loader',
-                        options: this.postCssOptions()
+                        include: /\.module\.css$/,
+                        use: [
+                            'style-loader',
+                            {
+                                loader: 'css-loader',
+                                options: {
+                                    importLoaders: 1,
+                                    modules: true
+                                }
+                            },
+                            {
+                                loader: 'postcss-loader',
+                                options: this.postCssOptions()
+                            }
+                        ]
+                    },
+                    {
+                        resourceQuery: /module/,
+                        use: [
+                            'style-loader',
+                            {
+                                loader: 'css-loader',
+                                options: {
+                                    importLoaders: 1,
+                                    modules: true
+                                }
+                            },
+                            {
+                                loader: 'postcss-loader',
+                                options: this.postCssOptions()
+                            }
+                        ]
+                    },
+                    {
+                        use: [
+                            'style-loader',
+                            {
+                                loader: 'css-loader',
+                                options: { importLoaders: 1 }
+                            },
+                            {
+                                loader: 'postcss-loader',
+                                options: this.postCssOptions()
+                            }
+                        ]
                     }
                 ]
             },
@@ -21,21 +62,71 @@ class Css extends AutomaticComponent {
             {
                 test: /\.scss$/,
                 exclude: this.excludePathsFor('sass'),
-                loaders: [
-                    'style-loader',
-                    { loader: 'css-loader', options: { modules: Config.enableCssModules } },
+                oneOf: [
                     {
-                        loader: 'postcss-loader',
-                        options: this.postCssOptions()
+                        include: /\.module\.scss$/,
+                        use: [
+                            'style-loader',
+                            {
+                                loader: 'css-loader',
+                                options: { modules: true }
+                            },
+                            {
+                                loader: 'postcss-loader',
+                                options: this.postCssOptions()
+                            },
+                            {
+                                loader: 'sass-loader',
+                                options: {
+                                    sassOptions: {
+                                        precision: 8,
+                                        outputStyle: 'expanded'
+                                    }
+                                }
+                            }
+                        ]
                     },
                     {
-                        loader: 'sass-loader',
-                        options: {
-                            sassOptions: {
-                                precision: 8,
-                                outputStyle: 'expanded'
+                        resourceQuery: /module/,
+                        use: [
+                            'style-loader',
+                            {
+                                loader: 'css-loader',
+                                options: { modules: true }
+                            },
+                            {
+                                loader: 'postcss-loader',
+                                options: this.postCssOptions()
+                            },
+                            {
+                                loader: 'sass-loader',
+                                options: {
+                                    sassOptions: {
+                                        precision: 8,
+                                        outputStyle: 'expanded'
+                                    }
+                                }
                             }
-                        }
+                        ]
+                    },
+                    {
+                        use: [
+                            'style-loader',
+                            'css-loader',
+                            {
+                                loader: 'postcss-loader',
+                                options: this.postCssOptions()
+                            },
+                            {
+                                loader: 'sass-loader',
+                                options: {
+                                    sassOptions: {
+                                        precision: 8,
+                                        outputStyle: 'expanded'
+                                    }
+                                }
+                            }
+                        ]
                     }
                 ]
             },
@@ -43,53 +134,173 @@ class Css extends AutomaticComponent {
             {
                 test: /\.sass$/,
                 exclude: this.excludePathsFor('sass'),
-                loaders: [
-                    'style-loader',
-                    { loader: 'css-loader', options: { modules: Config.enableCssModules } },
+                oneOf: [
                     {
-                        loader: 'postcss-loader',
-                        options: this.postCssOptions()
+                        include: /\.module\.sass$/,
+                        use: [
+                            'style-loader',
+                            {
+                                loader: 'css-loader',
+                                options: { modules: true }
+                            },
+                            {
+                                loader: 'postcss-loader',
+                                options: this.postCssOptions()
+                            },
+                            {
+                                loader: 'sass-loader',
+                                options: {
+                                    sassOptions: {
+                                        precision: 8,
+                                        outputStyle: 'expanded',
+                                        indentedSyntax: true
+                                    }
+                                }
+                            }
+                        ]
                     },
                     {
-                        loader: 'sass-loader',
-                        options: {
-                            sassOptions: {
-                                precision: 8,
-                                outputStyle: 'expanded',
-                                indentedSyntax: true
+                        resourceQuery: /module/,
+                        use: [
+                            'style-loader',
+                            {
+                                loader: 'css-loader',
+                                options: { modules: true }
+                            },
+                            {
+                                loader: 'postcss-loader',
+                                options: this.postCssOptions()
+                            },
+                            {
+                                loader: 'sass-loader',
+                                options: {
+                                    sassOptions: {
+                                        precision: 8,
+                                        outputStyle: 'expanded',
+                                        indentedSyntax: true
+                                    }
+                                }
                             }
-                        }
+                        ]
+                    },
+                    {
+                        use: [
+                            'style-loader',
+                            'css-loader',
+                            {
+                                loader: 'postcss-loader',
+                                options: this.postCssOptions()
+                            },
+                            {
+                                loader: 'sass-loader',
+                                options: {
+                                    sassOptions: {
+                                        precision: 8,
+                                        outputStyle: 'expanded',
+                                        indentedSyntax: true
+                                    }
+                                }
+                            }
+                        ]
                     }
                 ]
             },
 
             {
-                test: /\.less$/,
+                test: /\.less/,
                 exclude: this.excludePathsFor('less'),
-                loaders: [
-                    'style-loader',
-                    { loader: 'css-loader', options: { modules: Config.enableCssModules } },
+                oneOf: [
                     {
-                        loader: 'postcss-loader',
-                        options: this.postCssOptions()
+                        include: /\.module\.less$/,
+                        use: [
+                            'style-loader',
+                            {
+                                loader: 'css-loader',
+                                options: { modules: true }
+                            },
+                            {
+                                loader: 'postcss-loader',
+                                options: this.postCssOptions()
+                            },
+                            'less-loader'
+                        ]
                     },
-                    'less-loader'
+                    {
+                        resourceQuery: /module/,
+                        use: [
+                            'style-loader',
+                            {
+                                loader: 'css-loader',
+                                options: { modules: true }
+                            },
+                            {
+                                loader: 'postcss-loader',
+                                options: this.postCssOptions()
+                            },
+                            'less-loader'
+                        ]
+                    },
+                    {
+                        use: [
+                            'style-loader',
+                            'css-loader',
+                            {
+                                loader: 'postcss-loader',
+                                options: this.postCssOptions()
+                            },
+                            'less-loader'
+                        ]
+                    }
                 ]
             },
 
             {
                 test: /\.styl(us)?$/,
                 exclude: this.excludePathsFor('stylus'),
-                loaders: [
-                    'style-loader',
-                    { loader: 'css-loader', options: { modules: Config.enableCssModules } },
+                oneOf: [
                     {
-                        loader: 'postcss-loader',
-                        options: this.postCssOptions()
+                        include: /\.module\.styl(us)?$/,
+                        use: [
+                            'style-loader',
+                            {
+                                loader: 'css-loader',
+                                options: { modules: true }
+                            },
+                            {
+                                loader: 'postcss-loader',
+                                options: this.postCssOptions()
+                            },
+                            'stylus-loader'
+                        ]
                     },
-                    'stylus-loader'
+                    {
+                        resourceQuery: /module/,
+                        use: [
+                            'style-loader',
+                            {
+                                loader: 'css-loader',
+                                options: { modules: true }
+                            },
+                            {
+                                loader: 'postcss-loader',
+                                options: this.postCssOptions()
+                            },
+                            'stylus-loader'
+                        ]
+                    },
+                    {
+                        use: [
+                            'style-loader',
+                            'css-loader',
+                            {
+                                loader: 'postcss-loader',
+                                options: this.postCssOptions()
+                            },
+                            'stylus-loader'
+                        ]
+                    }
                 ]
-            }
+            },
         ];
     }
 

--- a/src/components/Vue.js
+++ b/src/components/Vue.js
@@ -45,9 +45,13 @@ class Vue {
     updateCssLoaders(webpackConfig) {
         // Basic CSS and PostCSS
         this.updateCssLoader('css', webpackConfig, rule => {
-            rule.loaders.find(
-                loader => loader.loader === 'postcss-loader'
-            ).options = this.postCssOptions();
+            rule.oneOf.forEach(
+                subrule => {
+                    subrule.use.find(
+                        loader => loader.loader === 'postcss-loader'
+                    ).options = this.postCssOptions();
+                }
+            )
         });
 
         // LESS
@@ -56,9 +60,13 @@ class Vue {
         // SASS
         let sassCallback = rule => {
             if (Mix.seesNpmPackage('sass')) {
-                rule.loaders.find(
-                    loader => loader.loader === 'sass-loader'
-                ).options.implementation = require('sass');
+                rule.oneOf.forEach(
+                    subrule => {
+                        subrule.use.find(
+                            loader => loader.loader === 'sass-loader'
+                        ).options.implementation = require('sass');
+                    }
+                )
             }
 
             if (Config.globalVueStyles) {

--- a/src/config.js
+++ b/src/config.js
@@ -214,15 +214,6 @@ module.exports = function() {
          * @type {Boolean}
          */
         clearConsole: true,
-        
-        /**
-         * Determine if css-loader CSS Modules support should be enabled
-         * 
-         * See: https://github.com/webpack-contrib/css-loader#modules
-         * 
-         * @type {Boolean|String|Object}
-         */
-        enableCssModules: false,
 
         /**
          * Merge the given options with the current defaults.

--- a/src/config.js
+++ b/src/config.js
@@ -214,6 +214,15 @@ module.exports = function() {
          * @type {Boolean}
          */
         clearConsole: true,
+        
+        /**
+         * Determine if css-loader CSS Modules support should be enabled
+         * 
+         * See: https://github.com/webpack-contrib/css-loader#modules
+         * 
+         * @type {Boolean|String|Object}
+         */
+        enableCssModules: false,
 
         /**
          * Merge the given options with the current defaults.


### PR DESCRIPTION
VueJS Single File Components with SCSS modules don't work without the css-loader modules option enabled, so this PR exposes this option