### PR TITLE
Fix issue #2342: minified files not copied in production

### DIFF
--- a/src/webpackPlugins/CustomTasksPlugin.js
+++ b/src/webpackPlugins/CustomTasksPlugin.js
@@ -50,13 +50,24 @@ class CustomTasksPlugin {
      * Minify the given asset file.
      */
     minifyAssets() {
+        const minifiedFiles = {};
+
         collect(Mix.tasks)
             .where('constructor.name', '!==', 'VersionFilesTask')
-            .where('constructor.name', '!==', 'CopyFilesTask')
             .each(({ assets }) =>
                 assets.forEach(asset => {
+                    // use the absolute path to the file as the file key
+                    const assetKey = asset.path();
+
+                    // only minify the file once
+                    if (minifiedFiles[assetKey]) {
+                        return;
+                    }
+
                     try {
+                        // minify the file, and remember to skip it if we've met the file again
                         asset.minify();
+                        minifiedFiles[assetKey] = true;
                     } catch (e) {
                         Log.error(
                             `Whoops! We had trouble minifying "${asset.relativePath()}". ` +

--- a/test/features/vue.js
+++ b/test/features/vue.js
@@ -19,7 +19,6 @@ test.serial.cb('it appends vue styles to your sass compiled file', t => {
   color: red;
 }
 
-
 .hello {
   color: blue;
 }`;
@@ -49,7 +48,6 @@ test.serial.cb('it prepends vue styles to your less compiled file', t => {
         let expected = `body {
   color: pink;
 }
-
 .hello {
   color: blue;
 }`;
@@ -75,8 +73,7 @@ test.serial.cb(
                 File.exists('test/fixtures/fake-app/public/css/vue-styles.css')
             );
 
-            let expected = `
-.hello {
+            let expected = `.hello {
   color: blue;
 }`;
 
@@ -121,8 +118,7 @@ test.serial.cb('it extracts vue Stylus styles to a dedicated file', t => {
     compile(t, config => {
         t.true(File.exists('test/fixtures/fake-app/public/css/components.css'));
 
-        let expected = `
-.hello {
+        let expected = `.hello {
   margin: 10px;
 }
 `;
@@ -174,8 +170,7 @@ test.serial.cb('it extracts vue .scss styles to a dedicated file', t => {
             File.find('test/fixtures/fake-app/public/css/app.css').read()
         );
 
-        expected = `
-.hello {
+        expected = `.hello {
   color: blue;
 }`;
 
@@ -213,8 +208,7 @@ test.serial.cb('it extracts vue .sass styles to a dedicated file', t => {
             File.find('test/fixtures/fake-app/public/css/app.css').read()
         );
 
-        expected = `
-.hello {
+        expected = `.hello {
   color: black;
 }`;
 
@@ -259,8 +253,7 @@ test.serial.cb('it extracts vue Less styles to a dedicated file', t => {
     compile(t, config => {
         t.true(File.exists('test/fixtures/fake-app/public/css/components.css'));
 
-        let expected = `
-.hello {
+        let expected = `.hello {
   color: blue;
 }
 `;


### PR DESCRIPTION
This PR is to fix the issue as mentioned in #2342, where in production, the minified files are not copying to the output location in the first run. 

This fix removes the restriction where `CopyFileTask`s are skipped. To mitigate the risk for minifying a file multiple times, we will remember which files have already been minfied, and skip them when encountered a 2nd time. 

In addition, I've fixed a few `Vue` tests where the minified/uglified CSS contents show LF only differences. 