### PR TITLE
Fix HMR (with versioning enabled)

### DIFF
--- a/src/Manifest.js
+++ b/src/Manifest.js
@@ -107,9 +107,13 @@ class Manifest {
                 .all();
         }
 
-        return collect(assets)
-            .flatten()
-            .all();
+        return (
+            collect(assets)
+                .flatten()
+                // Don't add hot updates to manifest
+                .filter(name => name.indexOf('hot-update') === -1)
+                .all()
+        );
     }
 
     /**

--- a/src/webpackPlugins/CustomTasksPlugin.js
+++ b/src/webpackPlugins/CustomTasksPlugin.js
@@ -12,7 +12,7 @@ class CustomTasksPlugin {
             this.constructor.name,
             (stats, callback) => {
                 this.runTasks(stats).then(() => {
-                    if (Mix.components.get('version')) {
+                    if (Mix.components.get('version') && !Mix.isUsing('hmr')) {
                         this.applyVersioning();
                     }
 


### PR DESCRIPTION
I found some bugs with both HRM and versioning enabled (related to "Mix Manifest" plugin _ mix-manifest.json).

### How to reproduce:

- You need to have, at least, one entry point in your webpack.mix.js config (e.g. "resources/js/app.js")
- Versioning need to be enabled (using "version" method)
- Run webpack-dev-server in inline and **hot** mode (be sure to have a clean output folder, don't run "webpack" before to create dist files)

--> Compilation seems to be OK and webpack-dev-server listening properly, but its not. You can't access to any assets (e.g. http://localhost:8080/js/app.js not responding)

### Fixes:

First, _applyVersioning_ (in CustomTasksPlugin) shoud be disabled in HMR because it tries to compute the hash of files (compiled assets) that don't exist on the disk. Webpack-dev-server, by default, do not write any file on the disk. Execution fails silently in _hash_ function (it was really hard to find out because, by default, nothing is ouputed in console! EDIT: errors are showing up using "master" branch vs "5.0.4")

Then, I found out another bug, when you update your entry point file (in my case _app.js_), Mix Manifest refresh itself and add the hot-update chunk file into its list. Then, try to get its hash (and fail because, hot-update chunk are not writen on the disk). Theses chunk should not be handled by Mix Manifest.


Feel free to ask me if you want more details about it. Thanks!
