### PR TITLE
Fix yargs mixfile

### DIFF
--- a/src/Paths.js
+++ b/src/Paths.js
@@ -28,7 +28,7 @@ class Paths {
      */
     mix() {
         return this.root(
-            argv.env && argv.env.mixfile ? argv.env.mixfile : 'webpack.mix'
+            argv.mixfile || 'webpack.mix'
         );
     }
 


### PR DESCRIPTION
I'm using Mix outside of Laravel. It appears the original intent was to allow for a custom mix file location. However, I couldn't find a way to pass nested Yargs arguments to `argv`. It seams `argv.env.mixfile` does not work. 