### PR TITLE
Feature/browsersync server arg

### DIFF
--- a/src/components/Browsersync.js
+++ b/src/components/Browsersync.js
@@ -46,27 +46,31 @@ class Browsersync {
      * Build the BrowserSync configuration.
      */
     config() {
-        return Object.assign(
-            {
-                host: 'localhost',
-                port: 3000,
-                proxy: 'app.test',
-                files: [
-                    'app/**/*.php',
-                    'resources/views/**/*.php',
-                    `${Config.publicPath || 'public'}/**/*.(js|css)`
-                ],
-                snippetOptions: {
-                    rule: {
-                        match: this.regex(),
-                        fn: function(snippet, match) {
-                            return snippet + match;
-                        }
+        let userConfig = this.userConfig;
+        let defaultConfig = {
+            host: 'localhost',
+            port: 3000,
+            proxy: 'app.test',
+            files: [
+                'app/**/*.php',
+                'resources/views/**/*.php',
+                `${Config.publicPath || 'public'}/**/*.(js|css)`
+            ],
+            snippetOptions: {
+                rule: {
+                    match: this.regex(),
+                    fn: function(snippet, match) {
+                        return snippet + match;
                     }
                 }
-            },
-            this.userConfig
-        );
+            }
+        };
+
+        if (userConfig && userConfig.server) {
+            delete defaultConfig.proxy;
+        }
+
+        return Object.assign(defaultConfig, userConfig);
     }
 }
 

--- a/test/features/browsersync.js
+++ b/test/features/browsersync.js
@@ -42,3 +42,23 @@ test.serial('it injects the snippet in the right place', t => {
         116
     );
 });
+
+test.serial('it configures Browsersync proxy', t => {
+    t.is(buildConfig().proxy, 'app.test', 'sets default proxy');
+    t.is(
+        buildConfig('example.domain').proxy,
+        'example.domain',
+        'sets proxy from string arg'
+    );
+    t.is(
+        buildConfig({ proxy: 'example.other.domain' }).proxy,
+        'example.other.domain',
+        'sets proxy from user Browsersync config'
+    );
+});
+
+let buildConfig = userConfig => {
+    let plugin = new Browsersync();
+    plugin.register(userConfig);
+    return plugin.config();
+};

--- a/test/features/browsersync.js
+++ b/test/features/browsersync.js
@@ -57,6 +57,16 @@ test.serial('it configures Browsersync proxy', t => {
     );
 });
 
+test.serial('it configures Browsersync server', t => {
+    let config = buildConfig({ server: './app' });
+    t.is(config.server, './app', 'sets server from user Browsersync config');
+    t.is(
+        config.proxy,
+        undefined,
+        'does not set default proxy when using server'
+    );
+});
+
 let buildConfig = userConfig => {
     let plugin = new Browsersync();
     plugin.register(userConfig);


### PR DESCRIPTION
Better support client-side projects w/ easy support for Browsersync `server` config option (don't set the default proxy when this is passed as user config).