### PR TITLE
Adds babel-loader to typescript rule

### DIFF
--- a/src/components/TypeScript.js
+++ b/src/components/TypeScript.js
@@ -38,13 +38,21 @@ class TypeScript extends JavaScript {
     webpackRules() {
         return [].concat(super.webpackRules(), {
             test: /\.tsx?$/,
-            loader: 'ts-loader',
             exclude: /node_modules/,
-            options: Object.assign(
-                {},
-                { appendTsSuffixTo: [/\.vue$/] },
-                this.options
-            )
+            use: [
+                {
+                    loader: 'babel-loader',
+                    options: Config.babel()
+                },
+                {
+                    loader: 'ts-loader',
+                    options: Object.assign(
+                        {},
+                        { appendTsSuffixTo: [/\.vue$/] },
+                        this.options
+                    )
+                }
+            ]
         });
     }
 


### PR DESCRIPTION
The Laravel Mix documentations states that it ships with TypeScript support, which is true.
It also states that you "Simply update your mix.js() call to mix.ts(), and then use the exact same set of arguments.".
To me, this implies that it will work exactly like js, except for actually compiling typescript files.
So I was quite surprised when I learned that the babel transformation that happens with js files doesn't for ts files.

As the use of babel is hardcoded with js, it would only make sense that it behaved the same with ts.

This implements babel support for ts the exact same way that it's implemented for js.