### PR TITLE
Fix Vue tests in master

### DIFF
--- a/test/features/vue.js
+++ b/test/features/vue.js
@@ -19,7 +19,6 @@ test.serial.cb('it appends vue styles to your sass compiled file', t => {
   color: red;
 }
 
-
 .hello {
   color: blue;
 }`;
@@ -49,7 +48,6 @@ test.serial.cb('it prepends vue styles to your less compiled file', t => {
         let expected = `body {
   color: pink;
 }
-
 .hello {
   color: blue;
 }`;
@@ -75,8 +73,7 @@ test.serial.cb(
                 File.exists('test/fixtures/fake-app/public/css/vue-styles.css')
             );
 
-            let expected = `
-.hello {
+            let expected = `.hello {
   color: blue;
 }`;
 
@@ -121,8 +118,7 @@ test.serial.cb('it extracts vue Stylus styles to a dedicated file', t => {
     compile(t, config => {
         t.true(File.exists('test/fixtures/fake-app/public/css/components.css'));
 
-        let expected = `
-.hello {
+        let expected = `.hello {
   margin: 10px;
 }
 `;
@@ -174,8 +170,7 @@ test.serial.cb('it extracts vue .scss styles to a dedicated file', t => {
             File.find('test/fixtures/fake-app/public/css/app.css').read()
         );
 
-        expected = `
-.hello {
+        expected = `.hello {
   color: blue;
 }`;
 
@@ -213,8 +208,7 @@ test.serial.cb('it extracts vue .sass styles to a dedicated file', t => {
             File.find('test/fixtures/fake-app/public/css/app.css').read()
         );
 
-        expected = `
-.hello {
+        expected = `.hello {
   color: black;
 }`;
 
@@ -259,8 +253,7 @@ test.serial.cb('it extracts vue Less styles to a dedicated file', t => {
     compile(t, config => {
         t.true(File.exists('test/fixtures/fake-app/public/css/components.css'));
 
-        let expected = `
-.hello {
+        let expected = `.hello {
   color: blue;
 }
 `;


### PR DESCRIPTION
Vue tests are currently failing master re: leading whitespace.

For some reason this fails locally but works on AppVeyor:
https://github.com/JeffreyWay/laravel-mix/pull/2402
https://ci.appveyor.com/project/JeffreyWay/laravel-mix/builds/32772331/job/3ggyh3453niye0ue

Local versions:
-   Laravel Mix Version (`npm list --depth=0`): 5.0.4
-   Node Version (`node -v`): 6.14.4
-   NPM Version (`npm -v`): 10.20.0
-   OS: WSL @ Ubuntu 18.04

AppVeyor versions:
-   Laravel Mix Version (`npm list --depth=0`): 5.0.4
-   Node Version (`node -v`): 6.14.5
-   NPM Version (`npm -v`): 10.20.1
-   OS: Windows?

Also, yes, nuked package-lock.json and node_modules, fresh install, still fails. Using a wrong version of node-sass/sass perhaps or is it a line-endings issue because AppVeyor is on Windows?