### PR TITLE
Respect processCssUrls option for Css-component

### DIFF
--- a/src/components/Css.js
+++ b/src/components/Css.js
@@ -23,7 +23,14 @@ class Css extends AutomaticComponent {
                 exclude: this.excludePathsFor('sass'),
                 loaders: [
                     'style-loader',
-                    'css-loader',
+                    {
+                        loader: 'css-loader',
+                        options: {
+                            url: Config.processCssUrls,
+                            sourceMap: Mix.isUsing('sourcemaps'),
+                            importLoaders: 2
+                        }
+                    },
                     {
                         loader: 'postcss-loader',
                         options: this.postCssOptions()


### PR DESCRIPTION
This change makes the Css-component respect the option to disable css url-parsing and allows styles loaded through JS-files to have sourcemaps.

Fixes #2415
