### PR TITLE
Remove unused line of code

### DIFF
--- a/src/Mix.js
+++ b/src/Mix.js
@@ -80,8 +80,6 @@ class Mix {
      * Determine if Mix should activate hot reloading.
      */
     shouldHotReload() {
-        new File(path.join(Config.publicPath, 'hot')).delete();
-
         return this.isUsing('hmr');
     }
 


### PR DESCRIPTION
The first line in the shouldHotReload() method in Mix.js
creates a new file and then immediately deletes it. Removing
the line does not affect the tests.