### PR TITLE
Add mix.alias

### DIFF
--- a/src/components/Alias.js
+++ b/src/components/Alias.js
@@ -1,0 +1,19 @@
+module.exports = class Alias {
+    /**
+     * Add resolution aliases to webpack's config
+     *
+     * @param {Record<string,string>} paths
+     */
+    register(paths) {
+        /** @type {Record<string, string>} */
+        this.aliases = { ...(this.aliases || {}), ...paths };
+    }
+
+    webpackConfig(webpackConfig) {
+        webpackConfig.resolve.alias = webpackConfig.resolve.alias || {};
+
+        for (const [alias, path] of Object.entries(this.aliases)) {
+            webpackConfig.resolve.alias[alias] = Mix.paths.root(path);
+        }
+    }
+};

--- a/src/components/ComponentFactory.js
+++ b/src/components/ComponentFactory.js
@@ -17,6 +17,7 @@ let components = [
     'Combine',
     'Copy',
     'Autoload',
+    'Alias',
     'Version',
     'Extend',
     'Extract',

--- a/test/features/alias.js
+++ b/test/features/alias.js
@@ -1,0 +1,18 @@
+import mix from './helpers/setup';
+import path from 'path';
+
+test.serial('it handles resolution aliases', async t => {
+    mix.alias({
+        '@': './foobar'
+    });
+
+    const { config } = await compile();
+
+    t.deepEqual(
+        {
+            '@': path.resolve(__dirname, '../../foobar'),
+            vue$: 'vue/dist/vue.common.js'
+        },
+        config.resolve.alias
+    );
+});


### PR DESCRIPTION
Inspired by https://twitter.com/reinink/status/1296897827847770118 and https://github.com/MaximVanhove/laravel-mix-alias

I so often add aliases for '@' and for packages in node_modules to ensure the ESM version gets loaded that I think a shortcut in core would be 🔥 

Based on top of the latest webpack 5 PR. Only the last commit is relevant.