### PR TITLE
[WIP] Add mix.vue

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,9 +96,9 @@
         "sinon": "^9.0.1",
         "stylus": "^0.54.5",
         "stylus-loader": "^3.0.2",
-        "vue": "^2.5.21",
+        "vue2": "npm:vue@^2.6.12",
         "vue-style-loader": "^4.0.2",
-        "vue-template-compiler": "^2.5.21"
+        "vue-template-compiler": "^2.6.12"
     },
     "engines": {
         "node": ">=12.14.0"

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     },
     "devDependencies": {
         "@babel/preset-react": "^7.0.0",
+        "@vue/compiler-sfc": "^3.0.0",
         "ava": "^1.4.1",
         "coffee-loader": "^1.0.0",
         "coffeescript": "^2.2.3",
@@ -97,6 +98,7 @@
         "stylus": "^0.54.5",
         "stylus-loader": "^3.0.2",
         "vue2": "npm:vue@^2.6.12",
+        "vue3": "npm:vue@^3.0.0",
         "vue-style-loader": "^4.0.2",
         "vue-template-compiler": "^2.6.12"
     },

--- a/src/builder/WebpackConfig.js
+++ b/src/builder/WebpackConfig.js
@@ -119,11 +119,7 @@ class WebpackConfig {
      */
     buildResolving() {
         this.webpackConfig.resolve = {
-            extensions: ['*', '.wasm', '.mjs', '.js', '.jsx', '.json', '.vue'],
-
-            alias: {
-                vue$: 'vue/dist/vue.common.js'
-            }
+            extensions: ['*', '.wasm', '.mjs', '.js', '.jsx', '.json'],
         };
 
         return this;

--- a/src/components/ComponentFactory.js
+++ b/src/components/ComponentFactory.js
@@ -18,6 +18,7 @@ let components = [
     'Copy',
     'Autoload',
     'Alias',
+    'Vue',
     'Version',
     'Extend',
     'Extract',

--- a/src/components/ComponentFactory.js
+++ b/src/components/ComponentFactory.js
@@ -19,6 +19,8 @@ let components = [
     'Autoload',
     'Alias',
     'Vue',
+    'React',
+    'Preact',
     'Version',
     'Extend',
     'Extract',

--- a/src/components/Css.js
+++ b/src/components/Css.js
@@ -175,6 +175,7 @@ class Css extends AutomaticComponent {
         const loaders = [];
 
         if (method === 'auto') {
+            // TODO: Fix
             if (Config.extractVueStyles !== false) {
                 method = 'extract';
             } else {

--- a/src/components/Css.js
+++ b/src/components/Css.js
@@ -1,7 +1,6 @@
 let mapValues = require('lodash').mapValues;
 let AutomaticComponent = require('./AutomaticComponent');
 let MiniCssExtractPlugin = require('mini-css-extract-plugin');
-let AppendVueStylesPlugin = require('../webpackPlugins/Css/AppendVueStylesPlugin');
 let RemoveCssOnlyChunksPlugin = require('../webpackPlugins/Css/RemoveCssOnlyChunksPlugin');
 
 class Css extends AutomaticComponent {
@@ -154,7 +153,6 @@ class Css extends AutomaticComponent {
      */
     webpackPlugins() {
         return [
-            new AppendVueStylesPlugin(),
             new RemoveCssOnlyChunksPlugin(),
             new MiniCssExtractPlugin({
                 filename: '[name].css',

--- a/src/components/Css.js
+++ b/src/components/Css.js
@@ -176,7 +176,7 @@ class Css extends AutomaticComponent {
 
         if (method === 'auto') {
             // TODO: Fix
-            if (Config.extractVueStyles !== false) {
+            if (Mix.extractingStyles !== false) {
                 method = 'extract';
             } else {
                 method = 'inline';
@@ -215,8 +215,8 @@ class Css extends AutomaticComponent {
     static beforeLoaders({ type, injectGlobalStyles }) {
         const loaders = [];
 
-        if (Config.globalVueStyles && injectGlobalStyles) {
-            let resources = Css.normalizeVueStyles()[type] || [];
+        if (Mix.globalStyles && injectGlobalStyles) {
+            let resources = Css.normalizeGlobalStyles(Mix.globalStyles)[type] || [];
 
             if (resources.length) {
                 loaders.push({
@@ -231,11 +231,9 @@ class Css extends AutomaticComponent {
         return loaders;
     }
 
-    static normalizeVueStyles() {
-        let styles = Config.globalVueStyles;
-
-        // Backwards compat:
-        // Config.globalVueStyles as a string only supported sass / scss
+    static normalizeGlobalStyles(styles) {
+        // Backwards compat with existing Config.globalVueStyles:
+        // A string only is supported for sass / scss
         if (typeof styles !== 'object') {
             styles = {
                 sass: styles,

--- a/src/components/JavaScript.js
+++ b/src/components/JavaScript.js
@@ -1,13 +1,9 @@
 let glob = require('glob');
 let Assert = require('../Assert');
-let Vue = require('./Vue');
 
 class JavaScript {
     constructor() {
-        this.vue = new Vue();
         this.toCompile = [];
-
-        JavaScript.vueWebpackConfigApplied = false;
     }
 
     /**
@@ -16,14 +12,7 @@ class JavaScript {
     name() {
         let name = this.constructor.name.toLowerCase();
 
-        return name === 'javascript' ? ['js', 'vue'] : name;
-    }
-
-    /**
-     * Required dependencies for the component.
-     */
-    dependencies() {
-        return this.vue.dependencies();
+        return name === 'javascript' ? 'js' : name;
     }
 
     /**
@@ -78,19 +67,6 @@ class JavaScript {
                 ]
             }
         ]);
-    }
-
-    /**
-     * Override the generated webpack configuration.
-     *
-     * @param {Object} webpackConfig
-     */
-    webpackConfig(webpackConfig) {
-        if (!JavaScript.vueWebpackConfigApplied) {
-            this.vue.webpackConfig(webpackConfig);
-        }
-
-        JavaScript.vueWebpackConfigApplied = true;
     }
 }
 

--- a/src/components/Preact.js
+++ b/src/components/Preact.js
@@ -1,6 +1,4 @@
-let JavaScript = require('./JavaScript');
-
-class Preact extends JavaScript {
+class Preact {
     /**
      * Required dependencies for the component.
      */

--- a/src/components/React.js
+++ b/src/components/React.js
@@ -1,6 +1,4 @@
-let JavaScript = require('./JavaScript');
-
-class React extends JavaScript {
+class React {
     /**
      * Required dependencies for the component.
      */

--- a/src/components/Sass.js
+++ b/src/components/Sass.js
@@ -10,7 +10,7 @@ class Sass extends Preprocessor {
         return tap(
             [
                 'sass-loader@8.*',
-                Mix.seesNpmPackage('node-sass') ? 'node-sass' : 'sass'
+                'sass'
             ],
             dependencies => {
                 if (Config.processCssUrls) {
@@ -51,12 +51,7 @@ class Sass extends Preprocessor {
                     precision: 8,
                     outputStyle: 'expanded'
                 },
-                // TODO: Fix Config.globalVueStyles
-                // TODO: Can we opt to always sass instead of node-sass?
-                implementation: () =>
-                    Mix.seesNpmPackage('node-sass') && !Config.globalVueStyles
-                        ? require('node-sass')
-                        : require('sass')
+                implementation: () => require('sass')
             },
             pluginOptions,
             { sourceMap: true }

--- a/src/components/Sass.js
+++ b/src/components/Sass.js
@@ -54,7 +54,7 @@ class Sass extends Preprocessor {
                 // TODO: Fix Config.globalVueStyles
                 // TODO: Can we opt to always sass instead of node-sass?
                 implementation: () =>
-                    Mix.seesNpmPackage('node-sass') && !Config.globalVVueStyles
+                    Mix.seesNpmPackage('node-sass') && !Config.globalVueStyles
                         ? require('node-sass')
                         : require('sass')
             },

--- a/src/components/Sass.js
+++ b/src/components/Sass.js
@@ -51,6 +51,8 @@ class Sass extends Preprocessor {
                     precision: 8,
                     outputStyle: 'expanded'
                 },
+                // TODO: Fix Config.globalVueStyles
+                // TODO: Can we opt to always sass instead of node-sass?
                 implementation: () =>
                     Mix.seesNpmPackage('node-sass') && !Config.globalVVueStyles
                         ? require('node-sass')

--- a/src/components/TypeScript.js
+++ b/src/components/TypeScript.js
@@ -42,6 +42,7 @@ class TypeScript extends JavaScript {
             exclude: /node_modules/,
             options: Object.assign(
                 {},
+                // TODO: Maybe move to Vue plugin?
                 { appendTsSuffixTo: [/\.vue$/] },
                 this.options
             )

--- a/src/components/TypeScript.js
+++ b/src/components/TypeScript.js
@@ -54,10 +54,7 @@ class TypeScript extends JavaScript {
      * @param {Object} config
      */
     webpackConfig(config) {
-        super.webpackConfig(config);
-
         config.resolve.extensions.push('.ts', '.tsx');
-        config.resolve.alias['vue$'] = 'vue/dist/vue.esm.js';
     }
 }
 

--- a/src/components/Vue.js
+++ b/src/components/Vue.js
@@ -11,7 +11,7 @@ class Vue {
      * Register the component.
      *
      * @param {object} options
-     * @param {2} [options.version] Which version of Vue to support. Detected automatically if not given.
+     * @param {2|3} [options.version] Which version of Vue to support. Detected automatically if not given.
      * @param {string|null} [options.globalStyles] A file to include w/ every vue style block.
      * @param {boolean|string} [options.extractStyles] Whether or not to extract vue styles. If given a string the name of the file to extract to.
      */
@@ -150,6 +150,10 @@ class Vue {
             return null
         }
 
+        if (vue.version.test(/^3\./)) {
+            return 3
+        }
+
         if (vue.version.test(/^2\./)) {
             return 2
         }
@@ -167,7 +171,7 @@ class Vue {
             throw new Error("Unable to detect vue version. Please specify a version when calling mix.vue")
         }
 
-        if (version !== 2) {
+        if (version !== 2 && version !== 3) {
             throw new Error(`Unsupported Vue version ${version}`)
         }
 
@@ -175,6 +179,10 @@ class Vue {
     }
 
     compilerName() {
+        if (this.version === 3) {
+            return '@vue/compiler-sfc'
+        }
+
         return 'vue-template-compiler'
     }
 

--- a/src/components/Vue.js
+++ b/src/components/Vue.js
@@ -27,8 +27,8 @@ class Vue {
         this.globalStyles = this.options.globalStyles || Config.globalVueStyles || null
         this.extractStyles = this.options.extractStyles || Config.extractVueStyles || false
 
-        Config.globalVueStyles = this.globalStyles
-        Config.extractVueStyles = this.extractStyles
+        Mix.globalStyles = this.globalStyles
+        Mix.extractingStyles = !!Config.extractVueStyles
     }
 
     /**

--- a/src/config.js
+++ b/src/config.js
@@ -138,7 +138,7 @@ module.exports = function() {
         extractVueStyles: false,
 
         /**
-         * Deprecated. Use mix.vue({ globalStyles: string|string[]|{[key: string]: string|string[]} })
+         * Deprecated. Use mix.vue({ globalStyles: {[key: string]: string|string[]} })
          * 
          * A file path with global styles that should be imported into every Vue component.
          *

--- a/src/config.js
+++ b/src/config.js
@@ -126,6 +126,8 @@ module.exports = function() {
         processCssUrls: true,
 
         /**
+         * Deprecated. Use mix.vue({ extractStyles: boolean|string })
+         * 
          * Should we extract .vue component styles into a dedicated file?
          * You may provide a boolean, or a dedicated path to extract to.
          *
@@ -136,6 +138,8 @@ module.exports = function() {
         extractVueStyles: false,
 
         /**
+         * Deprecated. Use mix.vue({ globalStyles: string|string[]|{[key: string]: string|string[]} })
+         * 
          * A file path with global styles that should be imported into every Vue component.
          *
          * This works with Sass, Less, CSS, etc…

--- a/test/features/alias.js
+++ b/test/features/alias.js
@@ -11,7 +11,6 @@ test.serial('it handles resolution aliases', async t => {
     t.deepEqual(
         {
             '@': path.resolve(__dirname, '../../foobar'),
-            vue$: 'vue/dist/vue.common.js'
         },
         config.resolve.alias
     );

--- a/test/features/extraction.js
+++ b/test/features/extraction.js
@@ -1,10 +1,11 @@
 import mix from './helpers/setup';
 
 test.serial.cb('JS compilation with vendor extraction config', t => {
+    mix.vue({ version: 2 })
     mix.js(
         'test/fixtures/fake-app/resources/assets/extract/app.js',
         'js'
-    ).extract(['vue'], 'js/libraries.js');
+    ).extract(['vue2'], 'js/libraries.js');
 
     compile(t, config => {
         t.true(File.exists('test/fixtures/fake-app/public/js/manifest.js'));
@@ -14,7 +15,7 @@ test.serial.cb('JS compilation with vendor extraction config', t => {
         t.true(
             new File('test/fixtures/fake-app/public/js/libraries.js')
                 .read()
-                .includes('vue')
+                .includes('vue2')
         );
     });
 });
@@ -22,7 +23,7 @@ test.serial.cb('JS compilation with vendor extraction config', t => {
 test.serial.cb(
     'vendor extraction with no requested JS compilation will still extract vendor libraries',
     t => {
-        mix.extract(['vue']);
+        mix.extract(['vue2']);
 
         compile(t, config => {
             t.true(File.exists('test/fixtures/fake-app/public/manifest.js'));
@@ -31,7 +32,7 @@ test.serial.cb(
             t.true(
                 new File('test/fixtures/fake-app/public/vendor.js')
                     .read()
-                    .includes('vue')
+                    .includes('vue2')
             );
         });
     }
@@ -40,10 +41,11 @@ test.serial.cb(
 test.serial.cb(
     'JS compilation with vendor extraction with default config',
     t => {
+        mix.vue({ version: 2 })
         mix.js(
             'test/fixtures/fake-app/resources/assets/extract/app.js',
             'js'
-        ).extract(['vue']);
+        ).extract(['vue2']);
 
         compile(t, config => {
             t.true(File.exists('test/fixtures/fake-app/public/js/manifest.js'));
@@ -53,13 +55,14 @@ test.serial.cb(
             t.true(
                 new File('test/fixtures/fake-app/public/js/vendor.js')
                     .read()
-                    .includes('vue')
+                    .includes('vue2')
             );
         });
     }
 );
 
 test.serial.cb('JS compilation with total vendor extraction', t => {
+    mix.vue({ version: 2 })
     mix.js(
         'test/fixtures/fake-app/resources/assets/extract/app.js',
         'js'

--- a/test/features/mix.js
+++ b/test/features/mix.js
@@ -4,7 +4,8 @@ test.serial.cb('the kitchen sink', t => {
     new File('test/fixtures/fake-app/public/file.js').write('var foo');
 
     mix.js('test/fixtures/fake-app/resources/assets/js/app.js', 'js')
-        .extract(['vue'])
+        .extract(['vue2'])
+        .vue({ version: 2 })
         .js('test/fixtures/fake-app/resources/assets/js/another.js', 'js')
         .sass('test/fixtures/fake-app/resources/assets/sass/app.scss', 'css')
         .postCss(
@@ -45,8 +46,9 @@ test.serial.cb('the kitchen sink', t => {
 });
 
 test.serial.cb('async chunk splitting works', t => {
+    mix.vue({ version: 2 })
     mix.js('test/fixtures/fake-app/resources/assets/extract/app.js', 'js')
-        .extract(['vue', 'lodash', 'core-js'])
+        .extract(['vue2', 'lodash', 'core-js'])
         .options({
             babelConfig: {
                 plugins: ['@babel/plugin-syntax-dynamic-import']
@@ -70,8 +72,9 @@ test.serial.cb('async chunk splitting works', t => {
 });
 
 test.serial.cb('multiple extractions work', t => {
+    mix.vue({ version: 2 })
     mix.js('test/fixtures/fake-app/resources/assets/extract/app.js', 'js')
-        .extract(['vue', 'lodash'], 'js/vendor-vue-lodash.js')
+        .extract(['vue2', 'lodash'], 'js/vendor-vue-lodash.js')
         .extract(['core-js'], 'js/vendor-core-js.js')
         .options({
             babelConfig: {

--- a/test/features/preprocessors.js
+++ b/test/features/preprocessors.js
@@ -1,32 +1,4 @@
 import mix from './helpers/setup';
-import SassComponent from '../../src/components/Sass';
-
-test.serial('mix.sass() requires the sass dependency by default.', t => {
-    Mix.seesNpmPackage = npmPackage => {
-        if (npmPackage === 'node-sass') return false;
-    };
-
-    let component = new SassComponent();
-
-    t.true(component.dependencies().includes('sass'));
-    t.false(component.dependencies().includes('node-sass'));
-});
-
-test.serial(
-    'mix.sass() requires node-sass dependency if the user has installed it.',
-    t => {
-        let component = new SassComponent();
-
-        Mix.seesNpmPackage = npmPackage => {
-            if (npmPackage === 'node-sass') return true;
-        };
-
-        component.dependencies();
-
-        t.true(component.dependencies().includes('node-sass'));
-        t.false(component.dependencies().includes('sass'));
-    }
-);
 
 test.serial.cb('it compiles Sass without JS', t => {
     mix.sass('test/fixtures/fake-app/resources/assets/sass/app.scss', 'css');

--- a/test/features/react.js
+++ b/test/features/react.js
@@ -1,9 +1,7 @@
 import mix from './helpers/setup';
 
 test.serial('mix.react()', t => {
-    let response = mix.react('resources/assets/js/app.js', 'public/js');
-
-    t.is(mix, response);
+    mix.react().js('resources/assets/js/app.js', 'public/js');
 
     t.deepEqual(
         [
@@ -12,12 +10,12 @@ test.serial('mix.react()', t => {
                 output: new File('public/js')
             }
         ],
-        Mix.components.get('react').toCompile
+        Mix.components.get('js').toCompile
     );
 });
 
 test.serial.cb('it compiles React and a preprocessor properly', t => {
-    mix.react('test/fixtures/fake-app/resources/assets/js/app.js', 'js').sass(
+    mix.react().js('test/fixtures/fake-app/resources/assets/js/app.js', 'js').sass(
         'test/fixtures/fake-app/resources/assets/sass/app.scss',
         'css'
     );
@@ -36,7 +34,7 @@ test.serial.cb('it compiles React and a preprocessor properly', t => {
 });
 
 test.serial('it sets the webpack entry correctly', t => {
-    mix.react('resources/assets/js/app.js', 'js');
+    mix.react().js('resources/assets/js/app.js', 'js');
 
     t.deepEqual(
         {
@@ -47,7 +45,7 @@ test.serial('it sets the webpack entry correctly', t => {
 });
 
 test.serial('it sets the babel config correctly', t => {
-    mix.react('resources/assets/js/app.js', 'js');
+    mix.react().js('resources/assets/js/app.js', 'js');
 
     buildConfig();
 

--- a/test/features/typescript.js
+++ b/test/features/typescript.js
@@ -30,8 +30,6 @@ test.serial.cb(
         compile(t, webpackConfig => {
             t.true(webpackConfig.resolve.extensions.includes('.ts'));
             t.true(webpackConfig.resolve.extensions.includes('.tsx'));
-
-            t.is('vue/dist/vue.esm.js', webpackConfig.resolve.alias['vue$']);
         });
     }
 );

--- a/test/features/vue.js
+++ b/test/features/vue.js
@@ -1,6 +1,7 @@
 import mix from './helpers/setup';
 
 test.serial.cb('it appends vue styles to your sass compiled file', t => {
+    mix.vue({ version: 2 })
     mix.js(
         'test/fixtures/fake-app/resources/assets/vue/app-with-vue-and-scss.js',
         'js/app.js'
@@ -33,6 +34,7 @@ test.serial.cb('it appends vue styles to your sass compiled file', t => {
 });
 
 test.serial.cb('it appends vue styles to your less compiled file', t => {
+    mix.vue({ version: 2 })
     mix.js(
         'test/fixtures/fake-app/resources/assets/vue/app-with-vue-and-scss.js',
         'js/app.js'
@@ -66,6 +68,7 @@ test.serial.cb('it appends vue styles to your less compiled file', t => {
 test.serial.cb(
     'it appends vue styles to a vue-styles.css file, if no preprocessor is used',
     t => {
+        mix.vue({ version: 2 })
         mix.js(
             'test/fixtures/fake-app/resources/assets/vue/app-with-vue-and-scss.js',
             'js/app.js'
@@ -93,6 +96,7 @@ test.serial.cb(
 );
 
 test.serial.cb('it extracts vue vanilla CSS styles to a dedicated file', t => {
+    mix.vue({ version: 2 })
     mix.js(
         'test/fixtures/fake-app/resources/assets/vue/app-with-vue-and-css.js',
         'js/app.js'
@@ -116,6 +120,7 @@ test.serial.cb('it extracts vue vanilla CSS styles to a dedicated file', t => {
 });
 
 test.serial.cb('it extracts vue Stylus styles to a dedicated file', t => {
+    mix.vue({ version: 2 })
     mix.js(
         'test/fixtures/fake-app/resources/assets/vue/app-with-vue-and-stylus.js',
         'js/app.js'
@@ -140,6 +145,7 @@ test.serial.cb('it extracts vue Stylus styles to a dedicated file', t => {
 test.serial(
     'it does also add the vue webpack rules with typescript component',
     t => {
+        mix.vue({ version: 2 })
         mix.ts('resources/assets/js/app.js', 'public/js');
 
         t.truthy(
@@ -151,6 +157,7 @@ test.serial(
 );
 
 test.serial.cb('it extracts vue .scss styles to a dedicated file', t => {
+    mix.vue({ version: 2 })
     mix.js(
         'test/fixtures/fake-app/resources/assets/vue/app-with-vue-and-scss.js',
         'js/app.js'
@@ -191,6 +198,7 @@ test.serial.cb('it extracts vue .scss styles to a dedicated file', t => {
 });
 
 test.serial.cb('it extracts vue .sass styles to a dedicated file', t => {
+    mix.vue({ version: 2 })
     mix.js(
         'test/fixtures/fake-app/resources/assets/vue/app-with-vue-and-indented-sass.js',
         'js/app.js'
@@ -231,6 +239,7 @@ test.serial.cb('it extracts vue .sass styles to a dedicated file', t => {
 });
 
 test.serial.cb('it extracts vue PostCSS styles to a dedicated file', t => {
+    mix.vue({ version: 2 })
     mix.js(
         'test/fixtures/fake-app/resources/assets/vue/app-with-vue-and-postcss.js',
         'js/app.js'
@@ -257,6 +266,7 @@ test.serial.cb('it extracts vue PostCSS styles to a dedicated file', t => {
 });
 
 test.serial.cb('it extracts vue Less styles to a dedicated file', t => {
+    mix.vue({ version: 2 })
     mix.js(
         'test/fixtures/fake-app/resources/assets/vue/app-with-vue-and-less.js',
         'js/app.js'
@@ -278,7 +288,7 @@ test.serial.cb('it extracts vue Less styles to a dedicated file', t => {
     });
 });
 
-test.serial.cb.only('it supports global Vue styles for sass', t => {
+test.serial.cb('it supports global Vue styles for sass', t => {
     Config.globalVueStyles = {
         css: ['test/fixtures/fake-app/resources/assets/css/global.css'],
         sass: ['test/fixtures/fake-app/resources/assets/sass/global.sass'],
@@ -286,6 +296,7 @@ test.serial.cb.only('it supports global Vue styles for sass', t => {
         less: ['test/fixtures/fake-app/resources/assets/less/global.less'],
         stylus: ['test/fixtures/fake-app/resources/assets/stylus/global.styl']
     };
+    mix.vue({ version: 2 })
     mix.js(
         'test/fixtures/fake-app/resources/assets/vue/app-with-vue-and-global-styles.js',
         'js/app.js'

--- a/test/features/vue3.js
+++ b/test/features/vue3.js
@@ -1,0 +1,345 @@
+import mix from './helpers/setup';
+
+test.serial.cb('it appends vue styles to your sass compiled file', t => {
+    mix.vue({ version: 3 })
+    mix.js(
+        'test/fixtures/fake-app/resources/assets/vue3/app-with-vue-and-scss.js',
+        'js/app.js'
+    )
+        .sass(
+            'test/fixtures/fake-app/resources/assets/sass/app.scss',
+            'css/app.css'
+        )
+        .options({ extractVueStyles: true });
+
+    compile(t, () => {
+        t.true(File.exists('test/fixtures/fake-app/public/js/app.js'));
+        t.true(File.exists('test/fixtures/fake-app/public/css/app.css'));
+
+        let expected = `body {
+  color: red;
+}
+
+
+.hello {
+  color: blue;
+}
+`;
+
+        t.is(
+            expected,
+            File.find('test/fixtures/fake-app/public/css/app.css').read()
+        );
+    });
+});
+
+test.serial.cb('it appends vue styles to your less compiled file', t => {
+    mix.vue({ version: 3 })
+    mix.js(
+        'test/fixtures/fake-app/resources/assets/vue3/app-with-vue-and-scss.js',
+        'js/app.js'
+    )
+        .less(
+            'test/fixtures/fake-app/resources/assets/less/main.less',
+            'css/app.css'
+        )
+        .options({ extractVueStyles: true });
+
+    compile(t, () => {
+        t.true(File.exists('test/fixtures/fake-app/public/js/app.js'));
+        t.true(File.exists('test/fixtures/fake-app/public/css/app.css'));
+
+        let expected = `body {
+  color: pink;
+}
+
+.hello {
+  color: blue;
+}
+`;
+
+        t.is(
+            expected,
+            File.find('test/fixtures/fake-app/public/css/app.css').read()
+        );
+    });
+});
+
+test.serial.cb(
+    'it appends vue styles to a vue-styles.css file, if no preprocessor is used',
+    t => {
+        mix.vue({ version: 3 })
+        mix.js(
+            'test/fixtures/fake-app/resources/assets/vue3/app-with-vue-and-scss.js',
+            'js/app.js'
+        ).options({ extractVueStyles: true });
+
+        compile(t, () => {
+            t.true(File.exists('test/fixtures/fake-app/public/js/app.js'));
+            t.true(
+                File.exists('test/fixtures/fake-app/public/css/vue-styles.css')
+            );
+
+            let expected = `.hello {
+  color: blue;
+}
+`;
+
+            t.is(
+                expected,
+                File.find(
+                    'test/fixtures/fake-app/public/css/vue-styles.css'
+                ).read()
+            );
+        });
+    }
+);
+
+test.serial.cb('it extracts vue vanilla CSS styles to a dedicated file', t => {
+    mix.vue({ version: 3 })
+    mix.js(
+        'test/fixtures/fake-app/resources/assets/vue3/app-with-vue-and-css.js',
+        'js/app.js'
+    ).options({ extractVueStyles: 'css/components.css' });
+
+    compile(t, config => {
+        t.true(File.exists('test/fixtures/fake-app/public/css/components.css'));
+
+        let expected = `
+.hello {
+    color: green;
+}
+
+`;
+
+        t.is(
+            expected,
+            File.find('test/fixtures/fake-app/public/css/components.css').read()
+        );
+    });
+});
+
+test.serial.cb('it extracts vue Stylus styles to a dedicated file', t => {
+    mix.vue({ version: 3 })
+    mix.js(
+        'test/fixtures/fake-app/resources/assets/vue3/app-with-vue-and-stylus.js',
+        'js/app.js'
+    ).options({ extractVueStyles: 'css/components.css' });
+
+    compile(t, config => {
+        t.true(File.exists('test/fixtures/fake-app/public/css/components.css'));
+
+        let expected = `.hello {
+  margin: 10px;
+}
+
+`;
+
+        t.is(
+            expected,
+            File.find('test/fixtures/fake-app/public/css/components.css').read()
+        );
+    });
+});
+
+test.serial(
+    'it does also add the vue webpack rules with typescript component',
+    t => {
+        mix.vue({ version: 3 })
+        mix.ts('resources/assets/js/app.js', 'public/js');
+
+        t.truthy(
+            buildConfig().module.rules.find(
+                rule => rule.test.toString() === '/\\.vue$/'
+            )
+        );
+    }
+);
+
+test.serial.cb('it extracts vue .scss styles to a dedicated file', t => {
+    mix.vue({ version: 3 })
+    mix.js(
+        'test/fixtures/fake-app/resources/assets/vue3/app-with-vue-and-scss.js',
+        'js/app.js'
+    )
+        .sass(
+            'test/fixtures/fake-app/resources/assets/sass/app.scss',
+            'css/app.css'
+        )
+        .options({ extractVueStyles: 'css/components.css' });
+
+    compile(t, config => {
+        t.true(File.exists('test/fixtures/fake-app/public/js/app.js'));
+        t.true(File.exists('test/fixtures/fake-app/public/css/app.css'));
+        t.true(File.exists('test/fixtures/fake-app/public/css/components.css'));
+
+        let expected = `body {
+  color: red;
+}
+
+
+`;
+
+        t.is(
+            expected,
+            File.find('test/fixtures/fake-app/public/css/app.css').read()
+        );
+
+        expected = `.hello {
+  color: blue;
+}
+`;
+
+        t.is(
+            expected,
+            File.find('test/fixtures/fake-app/public/css/components.css').read()
+        );
+    });
+});
+
+test.serial.cb('it extracts vue .sass styles to a dedicated file', t => {
+    mix.vue({ version: 3 })
+    mix.js(
+        'test/fixtures/fake-app/resources/assets/vue3/app-with-vue-and-indented-sass.js',
+        'js/app.js'
+    )
+        .sass(
+            'test/fixtures/fake-app/resources/assets/sass/app.scss',
+            'css/app.css'
+        )
+        .options({ extractVueStyles: 'css/components.css' });
+
+    compile(t, config => {
+        t.true(File.exists('test/fixtures/fake-app/public/js/app.js'));
+        t.true(File.exists('test/fixtures/fake-app/public/css/app.css'));
+        t.true(File.exists('test/fixtures/fake-app/public/css/components.css'));
+
+        let expected = `body {
+  color: red;
+}
+
+
+`;
+
+        t.is(
+            expected,
+            File.find('test/fixtures/fake-app/public/css/app.css').read()
+        );
+
+        expected = `.hello {
+  color: black;
+}
+`;
+
+        t.is(
+            expected,
+            File.find('test/fixtures/fake-app/public/css/components.css').read()
+        );
+    });
+});
+
+test.serial.cb('it extracts vue PostCSS styles to a dedicated file', t => {
+    mix.vue({ version: 3 })
+    mix.js(
+        'test/fixtures/fake-app/resources/assets/vue3/app-with-vue-and-postcss.js',
+        'js/app.js'
+    ).options({ extractVueStyles: 'css/components.css' });
+
+    compile(t, config => {
+        // In this example, postcss-loader is reading from postcss.config.js.
+        let expected = `
+:root {
+    --color: white;
+}
+.hello {
+    color: white;
+    color: var(--color);
+}
+
+`;
+
+        t.is(
+            expected,
+            File.find('test/fixtures/fake-app/public/css/components.css').read()
+        );
+    });
+});
+
+test.serial.cb('it extracts vue Less styles to a dedicated file', t => {
+    mix.vue({ version: 3 })
+    mix.js(
+        'test/fixtures/fake-app/resources/assets/vue3/app-with-vue-and-less.js',
+        'js/app.js'
+    ).options({ extractVueStyles: 'css/components.css' });
+
+    compile(t, config => {
+        t.true(File.exists('test/fixtures/fake-app/public/css/components.css'));
+
+        let expected = `.hello {
+  color: blue;
+}
+
+`;
+
+        t.is(
+            expected,
+            File.find('test/fixtures/fake-app/public/css/components.css').read()
+        );
+    });
+});
+
+test.serial.cb('it supports global Vue styles for sass', t => {
+    Config.globalVueStyles = {
+        css: ['test/fixtures/fake-app/resources/assets/css/global.css'],
+        sass: ['test/fixtures/fake-app/resources/assets/sass/global.sass'],
+        scss: ['test/fixtures/fake-app/resources/assets/sass/global.scss'],
+        less: ['test/fixtures/fake-app/resources/assets/less/global.less'],
+        stylus: ['test/fixtures/fake-app/resources/assets/stylus/global.styl']
+    };
+    mix.vue({ version: 3 })
+    mix.js(
+        'test/fixtures/fake-app/resources/assets/vue3/app-with-vue-and-global-styles.js',
+        'js/app.js'
+    );
+    mix.sass(
+        'test/fixtures/fake-app/resources/assets/sass/app.scss',
+        'css/app.css'
+    );
+    mix.options({ extractVueStyles: 'css/components.css' });
+
+    compile(t, () => {
+        t.true(File.exists('test/fixtures/fake-app/public/js/app.js'));
+        t.true(File.exists('test/fixtures/fake-app/public/css/components.css'));
+
+        let expected = `
+:root {
+    --shared-color: rebeccapurple;
+}
+.shared-css {
+    color: rebeccapurple;
+    color: var(--shared-color);
+}
+
+.shared-scss {
+  color: rebeccapurple;
+}
+.shared-sass {
+  color: rebeccapurple;
+}
+.shared-less {
+  color: rebeccapurple;
+}
+
+.shared-stylus {
+  color: #639;
+}
+`;
+
+        t.is(
+            expected.trim(),
+            File.find('test/fixtures/fake-app/public/css/components.css')
+                .read()
+                .trim()
+        );
+    });
+});

--- a/test/fixtures/fake-app/resources/assets/extract/app.js
+++ b/test/fixtures/fake-app/resources/assets/extract/app.js
@@ -1,4 +1,4 @@
-import 'vue';
+import 'vue2';
 import 'core-js';
 
 new Vue({

--- a/test/fixtures/fake-app/resources/assets/vue/app-with-vue-and-css.js
+++ b/test/fixtures/fake-app/resources/assets/vue/app-with-vue-and-css.js
@@ -1,4 +1,4 @@
-import 'vue';
+import 'vue2';
 import BasicWithCss from './BasicWithCss.vue';
 
 new Vue({

--- a/test/fixtures/fake-app/resources/assets/vue/app-with-vue-and-global-styles.js
+++ b/test/fixtures/fake-app/resources/assets/vue/app-with-vue-and-global-styles.js
@@ -1,4 +1,4 @@
-import 'vue';
+import 'vue2';
 import BasicWithGlobalStyles from './BasicWithGlobalStyles.vue';
 
 new Vue({

--- a/test/fixtures/fake-app/resources/assets/vue/app-with-vue-and-indented-sass.js
+++ b/test/fixtures/fake-app/resources/assets/vue/app-with-vue-and-indented-sass.js
@@ -1,4 +1,4 @@
-import 'vue';
+import 'vue2';
 import BasicWithIndentedSass from './BasicWithIndentedSass.vue';
 
 new Vue({

--- a/test/fixtures/fake-app/resources/assets/vue/app-with-vue-and-less.js
+++ b/test/fixtures/fake-app/resources/assets/vue/app-with-vue-and-less.js
@@ -1,4 +1,4 @@
-import 'vue';
+import 'vue2';
 import BasicWithLess from './BasicWithLess.vue';
 
 new Vue({

--- a/test/fixtures/fake-app/resources/assets/vue/app-with-vue-and-postcss.js
+++ b/test/fixtures/fake-app/resources/assets/vue/app-with-vue-and-postcss.js
@@ -1,4 +1,4 @@
-import 'vue';
+import 'vue2';
 import BasicWithPostCss from './BasicWithPostCss.vue';
 
 new Vue({

--- a/test/fixtures/fake-app/resources/assets/vue/app-with-vue-and-scss.js
+++ b/test/fixtures/fake-app/resources/assets/vue/app-with-vue-and-scss.js
@@ -1,4 +1,4 @@
-import 'vue';
+import 'vue2';
 import BasicWithScss from './BasicWithScss.vue';
 
 new Vue({

--- a/test/fixtures/fake-app/resources/assets/vue/app-with-vue-and-stylus.js
+++ b/test/fixtures/fake-app/resources/assets/vue/app-with-vue-and-stylus.js
@@ -1,4 +1,4 @@
-import 'vue';
+import 'vue2';
 import BasicWithStylus from './BasicWithStylus.vue';
 
 new Vue({

--- a/test/fixtures/fake-app/resources/assets/vue3/BasicWithCss.vue
+++ b/test/fixtures/fake-app/resources/assets/vue3/BasicWithCss.vue
@@ -1,0 +1,19 @@
+<template>
+    <div class="hello">{{ message }}</div>
+</template>
+
+<script>
+module.exports = {
+    data() {
+        return {
+            message: 'Hello World'
+        };
+    }
+};
+</script>
+
+<style>
+.hello {
+    color: green;
+}
+</style>

--- a/test/fixtures/fake-app/resources/assets/vue3/BasicWithGlobalStyles.vue
+++ b/test/fixtures/fake-app/resources/assets/vue3/BasicWithGlobalStyles.vue
@@ -1,0 +1,39 @@
+<template>
+    <div class="hello">{{ message }}</div>
+</template>
+
+<script>
+module.exports = {
+    data: () => ({
+        message: 'Hello World'
+    })
+};
+</script>
+
+<style lang="css">
+.shared-css {
+    color: var(--shared-color);
+}
+</style>
+
+<style lang="scss">
+.shared-scss {
+    color: $sharedColor;
+}
+</style>
+
+<style lang="sass">
+.shared-sass
+    color: $sharedColor
+</style>
+
+<style lang="less">
+.shared-less {
+    color: @sharedColor;
+}
+</style>
+
+<style lang="stylus">
+.shared-stylus
+    color sharedColor
+</style>

--- a/test/fixtures/fake-app/resources/assets/vue3/BasicWithIndentedSass.vue
+++ b/test/fixtures/fake-app/resources/assets/vue3/BasicWithIndentedSass.vue
@@ -1,0 +1,20 @@
+<template>
+    <div class="hello">{{ message }}</div>
+</template>
+
+<script>
+module.exports = {
+    data() {
+        return {
+            message: 'Hello World'
+        };
+    }
+};
+</script>
+
+<style lang="sass">
+$primary: black
+
+.hello
+    color: $primary
+</style>

--- a/test/fixtures/fake-app/resources/assets/vue3/BasicWithLess.vue
+++ b/test/fixtures/fake-app/resources/assets/vue3/BasicWithLess.vue
@@ -1,0 +1,21 @@
+<template>
+    <div class="hello">{{ message }}</div>
+</template>
+
+<script>
+module.exports = {
+    data() {
+        return {
+            message: 'Hello World'
+        };
+    }
+};
+</script>
+
+<style lang="less">
+@color: blue;
+
+.hello {
+    color: @color;
+}
+</style>

--- a/test/fixtures/fake-app/resources/assets/vue3/BasicWithPostCss.vue
+++ b/test/fixtures/fake-app/resources/assets/vue3/BasicWithPostCss.vue
@@ -1,0 +1,23 @@
+<template>
+    <div class="hello">{{ message }}</div>
+</template>
+
+<script>
+module.exports = {
+    data() {
+        return {
+            message: 'Hello World'
+        };
+    }
+};
+</script>
+
+<style>
+:root {
+    --color: white;
+}
+
+.hello {
+    color: var(--color);
+}
+</style>

--- a/test/fixtures/fake-app/resources/assets/vue3/BasicWithScss.vue
+++ b/test/fixtures/fake-app/resources/assets/vue3/BasicWithScss.vue
@@ -1,0 +1,19 @@
+<template>
+    <div class="hello">{{ message }}</div>
+</template>
+
+<script>
+module.exports = {
+    data() {
+        return {
+            message: 'Hello World'
+        };
+    }
+};
+</script>
+
+<style lang="scss">
+.hello {
+    color: blue;
+}
+</style>

--- a/test/fixtures/fake-app/resources/assets/vue3/BasicWithStylus.vue
+++ b/test/fixtures/fake-app/resources/assets/vue3/BasicWithStylus.vue
@@ -1,0 +1,20 @@
+<template>
+    <div class="hello">{{ message }}</div>
+</template>
+
+<script>
+module.exports = {
+    data() {
+        return {
+            message: 'Hello World'
+        };
+    }
+};
+</script>
+
+<style lang="styl">
+margin = 10px
+
+.hello
+    margin: margin
+</style>

--- a/test/fixtures/fake-app/resources/assets/vue3/app-with-vue-and-css.js
+++ b/test/fixtures/fake-app/resources/assets/vue3/app-with-vue-and-css.js
@@ -1,0 +1,8 @@
+import { createApp } from 'vue3';
+import BasicWithCss from './BasicWithCss.vue';
+
+createApp({
+    components: {
+        BasicWithCss
+    }
+}).mount('#app')

--- a/test/fixtures/fake-app/resources/assets/vue3/app-with-vue-and-global-styles.js
+++ b/test/fixtures/fake-app/resources/assets/vue3/app-with-vue-and-global-styles.js
@@ -1,0 +1,8 @@
+import { createApp } from 'vue3';
+import BasicWithGlobalStyles from './BasicWithGlobalStyles.vue';
+
+createApp({
+    components: {
+        BasicWithGlobalStyles
+    }
+}).mount('#app')

--- a/test/fixtures/fake-app/resources/assets/vue3/app-with-vue-and-indented-sass.js
+++ b/test/fixtures/fake-app/resources/assets/vue3/app-with-vue-and-indented-sass.js
@@ -1,0 +1,8 @@
+import { createApp } from 'vue3';
+import BasicWithIndentedSass from './BasicWithIndentedSass.vue';
+
+createApp({
+    components: {
+        BasicWithIndentedSass
+    }
+}).mount('#app')

--- a/test/fixtures/fake-app/resources/assets/vue3/app-with-vue-and-less.js
+++ b/test/fixtures/fake-app/resources/assets/vue3/app-with-vue-and-less.js
@@ -1,0 +1,8 @@
+import { createApp } from 'vue3';
+import BasicWithLess from './BasicWithLess.vue';
+
+createApp({
+    components: {
+        BasicWithLess
+    }
+}).mount('#app')

--- a/test/fixtures/fake-app/resources/assets/vue3/app-with-vue-and-postcss.js
+++ b/test/fixtures/fake-app/resources/assets/vue3/app-with-vue-and-postcss.js
@@ -1,0 +1,8 @@
+import { createApp } from 'vue3';
+import BasicWithPostCss from './BasicWithPostCss.vue';
+
+createApp({
+    components: {
+        BasicWithPostCss
+    }
+}).mount('#app')

--- a/test/fixtures/fake-app/resources/assets/vue3/app-with-vue-and-scss.js
+++ b/test/fixtures/fake-app/resources/assets/vue3/app-with-vue-and-scss.js
@@ -1,0 +1,8 @@
+import { createApp } from 'vue3';
+import BasicWithScss from './BasicWithScss.vue';
+
+createApp({
+    components: {
+        BasicWithScss
+    }
+}).mount('#app')

--- a/test/fixtures/fake-app/resources/assets/vue3/app-with-vue-and-stylus.js
+++ b/test/fixtures/fake-app/resources/assets/vue3/app-with-vue-and-stylus.js
@@ -1,0 +1,8 @@
+import { createApp } from 'vue3';
+import BasicWithStylus from './BasicWithStylus.vue';
+
+createApp({
+    components: {
+        BasicWithStylus
+    }
+}).mount('#app')

--- a/test/integration/mix.js
+++ b/test/integration/mix.js
@@ -4,7 +4,7 @@ import { chromium } from 'playwright';
 let browser;
 
 test.before(async () => (browser = await chromium.launch()));
-test.after.always(() => browser.close());
+test.after.always(() => browser && browser.close());
 test.beforeEach(() => {
     mix.setPublicPath('test/fixtures/integration/dist');
 });


### PR DESCRIPTION
First attempt supporting Vue 2 and Vue 3 as well as introducing the new mix.vue API mentioned in #2483.

This is a fairly big work in progress and I'm absolutely looking for feedback. I left a comment w/ an idea on how I think `mix.vue()` (as well as `mix.react()`) should work but I'll mirror it here to help centralize discussion:

It seems like `mix.js(…)` should still be used but `mix.vue()` and `mix.react()` are effectively _features_ that can be enabled for use in any language supported by mix.

I have not implemented this approach (yet) but my thinking is we could write something like the following:

```js
// 1.a. enable Vue 2.x support
mix.vue2() // or mix.vue3()

// 1.b. Alternative API which helps mentally enforce the idea that only one or the other is supported at one time. Not both.
mix.vue({ version: 2 }) // or mix.vue({ version: 3 })

// 2.a. Compile app JS
mix.js("app/js/app.js", "public/js/app.js")

// 2.b. alternatively compile app TypeScript
mix.ts("app/ts/app.ts", "public/js/app.js")
```