### PR TITLE
Customize dynamic import paths when compiling JS

### DIFF
--- a/src/builder/WebpackConfig.js
+++ b/src/builder/WebpackConfig.js
@@ -76,7 +76,20 @@ class WebpackConfig {
         this.webpackConfig.output = {
             path: Mix.isUsing('hmr') ? '/' : path.resolve(Config.publicPath),
             filename: '[name].js',
-            chunkFilename: '[name].js',
+
+            chunkFilename: pathData => {
+                let hasAbsolutePathChunkName =
+                    pathData.chunk.name && pathData.chunk.name.startsWith('/');
+
+                if (Mix.components.get('js') && !hasAbsolutePathChunkName) {
+                    let output = Mix.components.get('js').toCompile[0].output;
+
+                    return `${output.filePath}/[name].js`;
+                }
+
+                return '[name].js';
+            },
+
             publicPath: Mix.isUsing('hmr')
                 ? `${http}://${Config.hmrOptions.host}:${
                       Config.hmrOptions.port

--- a/test/features/javascript.js
+++ b/test/features/javascript.js
@@ -81,7 +81,7 @@ test('basic JS compilation config.', t => {
         {
             path: path.resolve(`${fakeApp}/public`),
             filename: '[name].js',
-            chunkFilename: '[name].js',
+            chunkFilename: webpackConfig.output.chunkFilename,
             publicPath: '/'
         },
         webpackConfig.output
@@ -104,14 +104,16 @@ test('basic JS compilation with a different public path', t => {
         'public-html'
     );
 
+    let webpackConfig = webpack.buildConfig();
+
     t.deepEqual(
         {
             path: path.resolve('public-html'),
             filename: '[name].js',
-            chunkFilename: '[name].js',
+            chunkFilename: webpackConfig.output.chunkFilename,
             publicPath: '/'
         },
-        webpack.buildConfig().output
+        webpackConfig.output
     );
 });
 

--- a/test/features/javascript.js
+++ b/test/features/javascript.js
@@ -39,7 +39,9 @@ test('it compiles JavaScript with dynamic import', async t => {
 
     assert.manifestEquals(
         {
-            '/js/dynamic.js': '/js/dynamic.js'
+            '/js/absolute.js': '/js/absolute.js',
+            '/js/dynamic.js': '/js/dynamic.js',
+            '/js/named.js': '/js/named.js'
         },
         t
     );

--- a/test/fixtures/fake-app/resources/assets/dynamic/dynamic-module-absolute.js
+++ b/test/fixtures/fake-app/resources/assets/dynamic/dynamic-module-absolute.js
@@ -1,0 +1,7 @@
+const dynamic = {
+    init: () => {
+        alert('dynamic absolute test');
+    }
+};
+
+export default dynamic;

--- a/test/fixtures/fake-app/resources/assets/dynamic/dynamic-module-named.js
+++ b/test/fixtures/fake-app/resources/assets/dynamic/dynamic-module-named.js
@@ -1,0 +1,7 @@
+const dynamic = {
+    init: () => {
+        alert('dynamic named test');
+    }
+};
+
+export default dynamic;

--- a/test/fixtures/fake-app/resources/assets/dynamic/dynamic.js
+++ b/test/fixtures/fake-app/resources/assets/dynamic/dynamic.js
@@ -1,1 +1,7 @@
-import('./dynamic-module').then(module => module.init());
+import('./dynamic-module').then(module => module.default.init());
+import(/* webpackChunkName: 'named' */ './dynamic-module-named').then(module =>
+    module.default.init()
+);
+import(/* webpackChunkName: '/js/absolute' */ './dynamic-module-absolute').then(
+    module => module.default.init()
+);

--- a/test/fixtures/fake-app/resources/assets/extract/app.js
+++ b/test/fixtures/fake-app/resources/assets/extract/app.js
@@ -4,6 +4,6 @@ import 'core-js';
 new Vue({
     components: {
         VueSplit: () =>
-            import(/* webpackChunkName: 'js/split' */ './VueSplit.vue')
+            import(/* webpackChunkName: '/js/split' */ './VueSplit.vue')
     }
 }).$mount('#app');


### PR DESCRIPTION
Fixes #2500 

It doesn't work for TypeScript yet. Got some things to set up before I can properly test it.