### PR TITLE
Add runtimeOnly option for Vue

### DIFF
--- a/src/components/Vue.js
+++ b/src/components/Vue.js
@@ -75,15 +75,24 @@ class Vue {
         webpackConfig.resolve.alias = webpackConfig.resolve.alias || {};
 
         if (!webpackConfig.resolve.alias['vue$']) {
-            webpackConfig.resolve.alias['vue$'] =
-                this.version === 2
-                    ? 'vue/dist/vue.esm.js'
-                    : 'vue/dist/vue.esm-bundler.js';
+            webpackConfig.resolve.alias['vue$'] = this.aliasPath();
         }
 
         webpackConfig.resolve.extensions.push('.vue');
 
         this.updateChunks();
+    }
+
+    aliasPath() {
+        if (this.version === 2) {
+            return this.options.runtimeOnly
+                ? 'vue/dist/vue.runtime.esm.js'
+                : 'vue/dist/vue.esm.js';
+        }
+
+        return this.options.runtimeOnly
+            ? 'vue/dist/vue.runtime.esm-bundler.js'
+            : 'vue/dist/vue.esm-bundler.js';
     }
 
     /**

--- a/test/features/vue.js
+++ b/test/features/vue.js
@@ -14,6 +14,15 @@ test('it adds the Vue 2 resolve alias', t => {
     t.is('vue/dist/vue.esm.js', webpack.buildConfig().resolve.alias.vue$);
 });
 
+test('it adds the Vue 2 runtime resolve alias', t => {
+    mix.vue({ version: 2, runtimeOnly: true });
+
+    t.is(
+        'vue/dist/vue.runtime.esm.js',
+        webpack.buildConfig().resolve.alias.vue$
+    );
+});
+
 test('it knows the Vue 2 compiler name', t => {
     mix.vue({ version: 2 });
 

--- a/test/features/vue3.js
+++ b/test/features/vue3.js
@@ -19,6 +19,15 @@ test('it adds the Vue 3 resolve alias', t => {
     );
 });
 
+test('it adds the Vue 3 runtime resolve alias', t => {
+    mix.vue({ version: 3, runtimeOnly: true });
+
+    t.is(
+        'vue/dist/vue.runtime.esm-bundler.js',
+        webpack.buildConfig().resolve.alias.vue$
+    );
+});
+
 test('it knows the Vue 3 compiler name', t => {
     mix.vue({ version: 3 });
 

--- a/test/features/vue3.js
+++ b/test/features/vue3.js
@@ -13,11 +13,10 @@ test.beforeEach(() => {
 test('it adds the Vue 3 resolve alias', t => {
     mix.vue({ version: 3, extractStyles: true });
 
-    Mix.dispatch('init');
-    let config = new WebpackConfig().build();
-    t.true(true);
-    //
-    // t.is('vue/dist/vue.esm-bundler.js', config.resolve.alias.vue$);
+    t.is(
+        'vue/dist/vue.esm-bundler.js',
+        webpack.buildConfig().resolve.alias.vue$
+    );
 });
 
 test('it knows the Vue 3 compiler name', t => {


### PR DESCRIPTION
Allows one to tell mix to use the runtime-only version of Vue without having to resort to using `mix.alias`