### PR TITLE
Extract only used chunks + configurable extraction support

### DIFF
--- a/src/builder/Entry.js
+++ b/src/builder/Entry.js
@@ -50,39 +50,6 @@ class Entry {
     }
 
     /**
-     * Add a vendor extraction.
-     *
-     * @param {Object} extraction
-     */
-    addExtraction(extraction) {
-        if (!Mix.bundlingJavaScript && !extraction.output) {
-            throw new Error(
-                'Please provide an output path as the second argument to mix.extract().'
-            );
-        }
-
-        let outputPath = extraction.output;
-
-        // If the extraction output path begins with a slash (forward or backward)
-        // then the path from the public directory determined below will be wrong
-        // on Windows, as a drive letter will be incorrectly prepended to
-        // (e.g. '/dist/vendor' -> 'C:\dist\vendor').
-        let startsWithSlash = ['\\', '/'].indexOf(outputPath[0]) >= 0;
-        outputPath = startsWithSlash ? outputPath.substr(1) : outputPath;
-
-        let vendorPath = outputPath
-            ? new File(outputPath)
-                  .pathFromPublic(Config.publicPath)
-                  .replace(/\.js$/, '')
-                  .replace(/\\/g, '/')
-            : path.join(this.base, 'vendor').replace(/\\/g, '/');
-
-        this.add(vendorPath, extraction.libs);
-
-        return vendorPath;
-    }
-
-    /**
      * Add a default entry script to the structure.
      */
     addDefault() {

--- a/src/components/Extract.js
+++ b/src/components/Extract.js
@@ -110,7 +110,7 @@ class Extract {
      * @param {string[]} libraries
      */
     buildLibraryRegex(libraries = []) {
-        let pattern = '(?<!node_modules.*)[\\\\/]node_modules[\\\\/]';
+        let pattern = '(?<!node_modules)[\\\\/]node_modules[\\\\/]';
         let extra = '';
 
         if (Array.isArray(libraries)) {

--- a/src/components/Extract.js
+++ b/src/components/Extract.js
@@ -92,10 +92,10 @@ class Extract {
             }
 
             config = { to: config };
+        } else if (typeof config === 'function') {
+            config = { test: config };
         } else if (Array.isArray(config)) {
             config = { test: this.buildLibraryRegex(config) };
-        } else {
-            config = {};
         }
 
         return {
@@ -107,7 +107,7 @@ class Extract {
 
     /**
      *
-     * @param {string[]} libraries
+     * @param {string[]|RegExp} libraries
      */
     buildLibraryRegex(libraries = []) {
         let pattern = '(?<!node_modules)[\\\\/]node_modules[\\\\/]';
@@ -115,10 +115,12 @@ class Extract {
 
         if (Array.isArray(libraries)) {
             extra = libraries.map(lib => `${lib}[\\\\/]`).join('|');
+        } else if (libraries instanceof RegExp) {
+            extra = libraries.source;
         } else {
             throw new Error(
                 `Unexpected type [${typeof libraries}] passed to mix.extract({ libraries: … }). ` +
-                    `You may pass an array of strings.`
+                    `You may pass either an array of strings or a regular expression.`
             );
         }
 

--- a/src/components/Extract.js
+++ b/src/components/Extract.js
@@ -52,18 +52,14 @@ class Extract {
         this.entry = entry;
         this.chunks.entry = entry;
 
+        if (!Mix.bundlingJavaScript) {
+            throw new Error('You must compile JS to extract vendor code');
+        }
+
         this.extractions.forEach(extraction => {
             extraction.output = this.extractionPath(extraction.output);
 
-            // FIXME: This is not ideal
-            // The webpack docs state that entries should not be used for vendor extraction
-            // However if there are no uses of a library then they will not be extracted
-            // Is there a better way to handle this?
-            if (extraction.libs.length) {
-                this.entry.addExtraction(extraction);
-            } else {
-                this.addChunk(extraction);
-            }
+            this.addChunk(extraction);
         });
     }
 

--- a/src/components/Extract.js
+++ b/src/components/Extract.js
@@ -54,6 +54,8 @@ class Extract {
 
         this.extractions.forEach(extraction => {
             const path = this.extractionPath(extraction.to);
+            const isDefaultVendorChunk =
+                extraction.to === null || extraction.to === undefined;
 
             this.chunks.add(
                 `vendor${this.extractions.indexOf(extraction)}`,
@@ -61,7 +63,8 @@ class Extract {
                 extraction.test,
                 {
                     chunks: 'all',
-                    enforce: true
+                    enforce: true,
+                    priority: isDefaultVendorChunk ? -10 : 0
                 }
             );
         });

--- a/test/features/extraction.js
+++ b/test/features/extraction.js
@@ -31,14 +31,14 @@ test('JS compilation with vendor extraction config', async t => {
     );
 });
 
-test('vendor extraction with no requested JS compilation will still extract vendor libraries', async t => {
+test('vendor extraction with no requested JS compilation will throw an error', async t => {
     mix.extract(['vue']);
 
-    await webpack.compile();
-
-    assert.fileExists(`test/fixtures/app/dist/manifest.js`, t);
-    assert.fileExists(`test/fixtures/app/dist/vendor.js`, t);
-    assert.fileContains(`test/fixtures/app/dist/vendor.js`, 'vue', t);
+    await t.throwsAsync(
+        webpack.compile(),
+        null,
+        'You must compile JS to extract vendor code'
+    );
 });
 
 test('JS compilation with vendor extraction with default config', async t => {

--- a/test/features/extraction.js
+++ b/test/features/extraction.js
@@ -11,18 +11,23 @@ test.beforeEach(() => webpack.setupVueAliases(2));
 test('JS compilation with vendor extraction config', async t => {
     mix.js(`test/fixtures/app/src/extract/app.js`, 'js')
         .vue({ version: 2 })
-        .extract(['vue'], 'js/libraries.js');
+        .extract(['vue2'], 'js/libraries.js');
 
     await webpack.compile();
 
-    t.true(File.exists(`test/fixtures/app/dist/js/manifest.js`));
-    t.true(File.exists(`test/fixtures/app/dist/js/libraries.js`));
-    t.true(File.exists(`test/fixtures/app/dist/js/app.js`));
+    assert.fileExists(`test/fixtures/app/dist/js/manifest.js`, t);
+    assert.fileExists(`test/fixtures/app/dist/js/libraries.js`, t);
+    assert.fileExists(`test/fixtures/app/dist/js/app.js`, t);
 
-    t.true(
-        new File(`test/fixtures/app/dist/js/libraries.js`)
-            .read()
-            .includes('vue')
+    // We extracted vue to the library file
+    assert.fileContains(`test/fixtures/app/dist/js/libraries.js`, 'vue2', t);
+
+    // But not core-js
+    assert.fileContains(`test/fixtures/app/dist/js/app.js`, 'core-js', t);
+    assert.fileDoesNotContain(
+        `test/fixtures/app/dist/js/libraries.js`,
+        'core-js',
+        t
     );
 });
 
@@ -31,26 +36,23 @@ test('vendor extraction with no requested JS compilation will still extract vend
 
     await webpack.compile();
 
-    t.true(File.exists(`test/fixtures/app/dist/manifest.js`));
-    t.true(File.exists(`test/fixtures/app/dist/vendor.js`));
-
-    t.true(new File(`test/fixtures/app/dist/vendor.js`).read().includes('vue'));
+    assert.fileExists(`test/fixtures/app/dist/manifest.js`, t);
+    assert.fileExists(`test/fixtures/app/dist/vendor.js`, t);
+    assert.fileContains(`test/fixtures/app/dist/vendor.js`, 'vue', t);
 });
 
 test('JS compilation with vendor extraction with default config', async t => {
     mix.js(`test/fixtures/app/src/extract/app.js`, 'js')
         .vue({ version: 2 })
-        .extract(['vue']);
+        .extract(['vue2']);
 
     await webpack.compile();
 
-    t.true(File.exists(`test/fixtures/app/dist/js/manifest.js`));
-    t.true(File.exists(`test/fixtures/app/dist/js/vendor.js`));
-    t.true(File.exists(`test/fixtures/app/dist/js/app.js`));
+    assert.fileExists(`test/fixtures/app/dist/js/manifest.js`, t);
+    assert.fileExists(`test/fixtures/app/dist/js/vendor.js`, t);
+    assert.fileExists(`test/fixtures/app/dist/js/app.js`, t);
 
-    t.true(
-        new File(`test/fixtures/app/dist/js/vendor.js`).read().includes('vue')
-    );
+    assert.fileContains(`test/fixtures/app/dist/js/vendor.js`, 'vue2', t);
 });
 
 test('JS compilation with total vendor extraction', async t => {
@@ -60,9 +62,12 @@ test('JS compilation with total vendor extraction', async t => {
 
     await webpack.compile();
 
-    t.true(File.exists(`test/fixtures/app/dist/js/manifest.js`));
-    t.true(File.exists(`test/fixtures/app/dist/js/vendor.js`));
-    t.true(File.exists(`test/fixtures/app/dist/js/app.js`));
+    assert.fileExists(`test/fixtures/app/dist/js/manifest.js`, t);
+    assert.fileExists(`test/fixtures/app/dist/js/vendor.js`, t);
+    assert.fileExists(`test/fixtures/app/dist/js/app.js`, t);
+
+    assert.fileContains(`test/fixtures/app/dist/js/vendor.js`, 'vue2', t);
+    assert.fileContains(`test/fixtures/app/dist/js/vendor.js`, 'core-js', t);
 
     let fs = require('fs-extra');
     fs.removeSync('test/fixtures/app/public');
@@ -81,7 +86,7 @@ test('async chunk splitting works', async t => {
 
     await webpack.compile();
 
-    t.true(File.exists(`test/fixtures/app/dist/js/app.js`));
+    assert.fileExists(`test/fixtures/app/dist/js/app.js`, t);
 
     assert.manifestEquals(
         {
@@ -108,7 +113,7 @@ test('multiple extractions work', async t => {
 
     await webpack.compile();
 
-    t.true(File.exists(`test/fixtures/app/dist/js/app.js`));
+    assert.fileExists(`test/fixtures/app/dist/js/app.js`, t);
 
     assert.manifestEquals(
         {

--- a/test/features/mix.js
+++ b/test/features/mix.js
@@ -11,7 +11,7 @@ test('the kitchen sink', async t => {
     new File(`test/fixtures/app/dist/file.js`).write('var foo');
 
     mix.js(`test/fixtures/app/src/js/app.js`, 'js')
-        .extract(['vue'])
+        .extract(['vue2'])
         .vue({ version: 2 })
         .js(`test/fixtures/app/src/js/another.js`, 'js')
         .sass(`test/fixtures/app/src/sass/app.scss`, 'css')

--- a/test/fixtures/app/src/extract/app.js
+++ b/test/fixtures/app/src/extract/app.js
@@ -1,9 +1,16 @@
-import 'vue2';
 import 'core-js';
+import Vue from 'vue2';
+import { uniq } from 'lodash';
+import { auto } from 'eol';
 
 new Vue({
     components: {
         VueSplit: () =>
             import(/* webpackChunkName: '/js/split' */ './VueSplit.vue')
+    },
+
+    created() {
+        uniq(['foo', 'bar', 'foo']);
+        auto('foo\nbar');
     }
 }).$mount('#app');

--- a/test/fixtures/app/src/js/app.js
+++ b/test/fixtures/app/src/js/app.js
@@ -1,1 +1,3 @@
+import Vue from 'vue2';
+new Vue({ el: '#app' });
 alert('stub');

--- a/test/helpers/assertions.js
+++ b/test/helpers/assertions.js
@@ -14,6 +14,26 @@ export default {
     },
 
     /**
+     * Assert that a file exists
+     *
+     * @param {string} path
+     * @param {import("ava").Assertions} t
+     */
+    fileExists: (path, t) => {
+        t.true(File.exists(path));
+    },
+
+    /**
+     * Assert that a file does not exist
+     *
+     * @param {string} path
+     * @param {import("ava").Assertions} t
+     */
+    fileDoesNotExist: (path, t) => {
+        t.false(File.exists(path));
+    },
+
+    /**
      * Assert that a file isn't empty.
      *
      * @param {string} path
@@ -42,5 +62,27 @@ export default {
                 .replace(/\s/g, ''),
             expected.replace(/\s/g, '')
         );
+    },
+
+    /**
+     * Assert that a file contains the given string
+     *
+     * @param {string} path
+     * @param {string} expected
+     * @param {import("ava").Assertions} t
+     */
+    fileContains: (path, str, t) => {
+        t.true(new File(path).read().includes(str));
+    },
+
+    /**
+     * Assert that a file does not contain the given string
+     *
+     * @param {string} path
+     * @param {string} expected
+     * @param {import("ava").Assertions} t
+     */
+    fileDoesNotContain: (path, str, t) => {
+        t.false(new File(path).read().includes(str));
     }
 };

--- a/typings/extract.d.ts
+++ b/typings/extract.d.ts
@@ -18,7 +18,7 @@ export type Extraction = {
     test: RegExp | ExtractTestCallback;
 
     /** A list of libraries to match against */
-    libraries: string[];
+    libraries: string[] | RegExp;
 };
 
 export type ExtractConfig =
@@ -27,6 +27,9 @@ export type ExtractConfig =
 
     // A list of vendor files
     | string[]
+
+    // Custom extraction test function
+    | ExtractTestCallback
 
     // Extraction config
     | Partial<Extraction>;

--- a/typings/extract.d.ts
+++ b/typings/extract.d.ts
@@ -1,0 +1,32 @@
+import { Module } from 'webpack';
+
+/**
+ * Specify a custom extraction test
+ * Equivalent to providing a function to webpack's split chunks
+ */
+export type ExtractTestCallback = ((module: Module, context: any) => boolean);
+
+/**
+ * Specify a custom extraction test
+ * Can be a regular expression or a function
+ */
+export type Extraction = {
+    /** The path to extract files to */
+    to: string;
+
+    /** A custom test regex or callback — takes precedence over libraries  */
+    test: RegExp | ExtractTestCallback;
+
+    /** A list of libraries to match against */
+    libraries: string[];
+};
+
+export type ExtractConfig =
+    // A filename for node_modules extractions
+    | string
+
+    // A list of vendor files
+    | string[]
+
+    // Extraction config
+    | Partial<Extraction>;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -14,6 +14,7 @@ import { Options as SvgoConfig } from 'imagemin-svgo';
 import { TransformOptions as BabelConfig } from 'babel-core';
 import { Options as BrowserSyncConfig } from 'browser-sync';
 import { TerserPluginOptions } from 'terser-webpack-plugin';
+import * as ExtractTypes from './extract';
 
 interface MixConfig {
     production?: boolean;
@@ -81,9 +82,13 @@ declare module 'laravel-mix' {
                   ) => void)
         ) => Api;
         type Extract =
-            | (() => Api)
-            | ((output: string) => Api)
-            | ((libs: string | string[], output: string) => Api);
+            | ((output?: string) => Api)
+            | ((libs: string[], output?: string) => Api)
+            | ((test: ExtractTypes.ExtractTestCallback, output?: string) => Api)
+            | ((
+                  config: Partial<ExtractTypes.Extraction>,
+                  output?: string
+              ) => Api);
         type Notifications = () => Api;
         type Version = (files?: string | string[]) => Api;
 

--- a/upgrade.md
+++ b/upgrade.md
@@ -90,6 +90,40 @@ mix.sass('resources/sass/app.sass', 'public/css', {
 mix.sass('resources/sass/app.sass', 'public/css');
 ```
 
+### Changes to unused library extraction
+
+Mix when given `mix.extract(["library-1", "library-2"])` would previously extract libraries to a file regardless of whether or not they're used in the main JS bundle. Now, in Mix 6, we extract only the libraries that are used by your JS bundle. This means that these libraries are now also eligible for tree-shaking.
+
+With this change libraries should no longer be duplicated in multiple files. For example, if you used `vue` in your JS bundle and called `mix.extract(["vue])` it was possible in some scenarios for Vue to be included in each the vendor file and your app js file. This should no longer happen.
+
+Should you need to preserve the behavior of all listed libraries being included you can create a file that imports the necessary libraries. It may also be necessary for you to disable tree-shaking optimizations.
+
+##### Before
+
+```js
+// webpack.mix.js
+mix.extract(['library-1', 'library-2']);
+```
+
+##### After
+
+```js
+// src/libraries.js
+import 'library-1';
+import 'library-2';
+
+// webpack.mix.js
+mix.js('src/libraries.js');
+mix.extract(['library-1', 'library-2']);
+mix.webpackConfig({
+    optimization: {
+        providedExports: false,
+        sideEffects: false,
+        usedExports: false
+    }
+});
+```
+
 # Updates
 
 -   Support for webpack 5


### PR DESCRIPTION
Closes #2507

I've opted to change the behavior to never use entries for vendor extraction per the webpack documentation (https://webpack.js.org/concepts/entry-points/). If the user wants this behavior back I believe they'd need to create a file that imports all of the necessary libraries and compile it. Because of this behavior change I've not included the `when` parameter.