### PR TITLE
Fix typings

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -57,7 +57,8 @@ interface MixConfig {
 }
 
 declare module 'laravel-mix' {
-    export = Api;
+    declare const api: Api;
+    export = api;
 
     namespace builder {
         interface Entry {}
@@ -149,7 +150,7 @@ declare module 'laravel-mix' {
         webpackRules?: () => webpack.RuleSetRule | webpack.RuleSetRule[];
     }
 
-    class Api {
+    interface Api {
         sourceMaps(
             generateForProduction?: boolean,
             devType?: string,


### PR DESCRIPTION
Export the right type to TypeScript. There's still some tweaks that need to be made but this results in far less typescript errors.