### PR TITLE
Fail on stat errors

### DIFF
--- a/test/features/dumpwebpackconfig.js
+++ b/test/features/dumpwebpackconfig.js
@@ -11,7 +11,7 @@ test('mix.dumpWebpackConfig()', async t => {
         config = JSON.parse(webpackConfig);
     };
 
-    mix.js('test/fixtures/app/js/app.js', 'js').dumpWebpackConfig();
+    mix.js('test/fixtures/app/src/js/app.js', 'js').dumpWebpackConfig();
 
     await webpack.compile();
 

--- a/test/features/typescript.js
+++ b/test/features/typescript.js
@@ -24,7 +24,7 @@ test('mix.ts()', t => {
 });
 
 test('it applies the correct extensions and aliases to the webpack config', async t => {
-    mix.ts(`test/fixtures/app/js/app.js`, 'dist');
+    mix.ts(`test/fixtures/app/src/js/app.js`, 'dist');
 
     let { config } = await webpack.compile();
 

--- a/test/helpers/webpack.js
+++ b/test/helpers/webpack.js
@@ -13,6 +13,12 @@ export async function compile(config) {
         webpack(config, (err, stats) => {
             if (err) {
                 reject({ config, err, stats });
+            } else if (stats.hasErrors()) {
+                const { errors } = stats.toJson({ errors: true });
+
+                reject(
+                    new Error(errors.map(error => error.message).join('\n'))
+                );
             } else {
                 resolve({ config, err, stats });
             }


### PR DESCRIPTION
These tests were failing but not showing as failed because stat errors weren't being caught.