### PR TITLE
Show error for old style use of mix.react/preact/vue

### DIFF
--- a/src/components/Preact.js
+++ b/src/components/Preact.js
@@ -6,6 +6,18 @@ class Preact {
         return ['babel-preset-preact'];
     }
 
+    register() {
+        if (
+            arguments.length === 2 &&
+            typeof arguments[0] === 'string' &&
+            typeof arguments[1] === 'string'
+        ) {
+            throw new Error(
+                'mix.preact() is now a feature flag. Use mix.js(source, destination).preact() instead'
+            );
+        }
+    }
+
     /**
      * Babel config to be merged with Mix's defaults.
      */

--- a/src/components/React.js
+++ b/src/components/React.js
@@ -6,6 +6,18 @@ class React {
         return ['@babel/preset-react'];
     }
 
+    register() {
+        if (
+            arguments.length === 2 &&
+            typeof arguments[0] === 'string' &&
+            typeof arguments[1] === 'string'
+        ) {
+            throw new Error(
+                'mix.react() is now a feature flag. Use mix.js(source, destination).react() instead'
+            );
+        }
+    }
+
     /**
      * Babel config to be merged with Mix's defaults.
      */

--- a/src/components/Vue.js
+++ b/src/components/Vue.js
@@ -20,6 +20,16 @@ class Vue {
      * @param {boolean|string} [options.extractStyles] Whether or not to extract vue styles. If given a string the name of the file to extract to.
      */
     register(options = {}) {
+        if (
+            arguments.length === 2 &&
+            typeof arguments[0] === 'string' &&
+            typeof arguments[1] === 'string'
+        ) {
+            throw new Error(
+                'mix.vue() is a feature flag. Use mix.js(source, destination).vue() instead'
+            );
+        }
+
         this.version = VueVersion.detect(options.version);
 
         this.options = Object.assign(

--- a/test/features/react.js
+++ b/test/features/react.js
@@ -53,3 +53,15 @@ test('it sets the babel config correctly', t => {
         ) !== undefined
     );
 });
+
+test('non-feature-flag use of mix.react throws an error', t => {
+    t.throws(() => mix.react('js/app.js', 'js'), {
+        message: /mix.react\(\) is now a feature flag/
+    });
+});
+
+test('non-feature-flag use of mix.preact throws an error', t => {
+    t.throws(() => mix.react('js/app.js', 'js'), {
+        message: /mix.react\(\) is now a feature flag/
+    });
+});

--- a/test/features/vue.js
+++ b/test/features/vue.js
@@ -15,6 +15,12 @@ test('it adds the Vue 2 resolve alias', t => {
     t.is('vue/dist/vue.esm.js', webpack.buildConfig().resolve.alias.vue$);
 });
 
+test('non-feature-flag use of mix.vue throws an error', t => {
+    t.throws(() => mix.vue('js/app.js', 'js'), {
+        message: /mix.vue\(\) is a feature flag/
+    });
+});
+
 test('it adds the Vue 2 runtime resolve alias', t => {
     mix.vue({ version: 2, runtimeOnly: true });
 


### PR DESCRIPTION
Show an error explaining what to do when people are upgrading and type any of the following:

```js
mix.preact("js/app.js", "public/js")
mix.react("js/app.js", "public/js")
mix.vue("js/app.js", "public/js")
```