### PR TITLE
Adds an ability to specify the path for the `manifest.js`

### DIFF
--- a/docs/extract.md
+++ b/docs/extract.md
@@ -38,6 +38,16 @@ Once you compile your code - `npx mix` - you'll find three new files: `app.js`, 
 
 While it's true that we're now importing three scripts instead of one, the benefit is improved long-term caching of vendor code that rarely changes. Further, HTTP2 makes the cost of importing multiple scripts a non-issue.
 
+### Customizing the runtime chunk (`manifest.js`) path
+
+By default, the runtime chunk (`manifest.js`) is generated to a public directory.
+
+However, the path can easily be customized:
+
+```js
+mix.options({ runtimeChunkPath: 'js' });
+```
+
 ### The Manifest File
 
 You might still be confused by that third `manifest.js` file. Webpack compiles with a small bit of run-time code to assist with its job. When not using `mix.extract()`, this code is invisible to you and lives inside your bundle file. However, if we need to split our code, that runtime code must "live" somewhere. As such, Laravel Mix will extract it to its own file.

--- a/src/Chunks.js
+++ b/src/Chunks.js
@@ -119,7 +119,7 @@ class Chunks {
 
         return {
             runtimeChunk: {
-                name: path.join(this.entry.base, 'manifest').replace(/\\/g, '/')
+                name: path.join(Config.manifestJsPath || this.entry.base, 'manifest').replace(/\\/g, '/')
             }
         };
     }

--- a/src/Chunks.js
+++ b/src/Chunks.js
@@ -119,7 +119,7 @@ class Chunks {
 
         return {
             runtimeChunk: {
-                name: path.join(Config.manifestJsPath || this.entry.base, 'manifest').replace(/\\/g, '/')
+                name: path.join(Config.runtimeChunkPath, 'manifest').replace(/\\/g, '/')
             }
         };
     }

--- a/src/config.js
+++ b/src/config.js
@@ -53,6 +53,13 @@ module.exports = function() {
         publicPath: '',
 
         /**
+         * The path for the `manifest.js`.
+         *
+         * @type {String}
+         */
+        manifestJsPath: '',
+
+        /**
          * Determine if error notifications should be displayed for each build.
          *
          * @type {Boolean}

--- a/src/config.js
+++ b/src/config.js
@@ -7,9 +7,7 @@ module.exports = function() {
          *
          * @type {Boolean}
          */
-        production:
-            process.env.NODE_ENV === 'production' ||
-            process.argv.includes('-p'),
+        production: process.env.NODE_ENV === 'production' || process.argv.includes('-p'),
 
         /**
          * Determine if we should enable hot reloading.
@@ -53,11 +51,11 @@ module.exports = function() {
         publicPath: '',
 
         /**
-         * The path for the `manifest.js`.
+         * The path for the runtime chunk (`manifest.js`).
          *
          * @type {String}
          */
-        manifestJsPath: '',
+        runtimeChunkPath: '',
 
         /**
          * Determine if error notifications should be displayed for each build.
@@ -115,10 +113,7 @@ module.exports = function() {
         babel: function(babelRcPath) {
             babelRcPath = babelRcPath || Mix.paths.root('.babelrc');
 
-            return require('./BabelConfig').generate(
-                this.babelConfig,
-                babelRcPath
-            );
+            return require('./BabelConfig').generate(this.babelConfig, babelRcPath);
         },
 
         /**

--- a/test/features/extraction.js
+++ b/test/features/extraction.js
@@ -24,11 +24,7 @@ test('JS compilation with vendor extraction config', async t => {
 
     // But not core-js
     assert.fileContains(`test/fixtures/app/dist/js/app.js`, 'core-js', t);
-    assert.fileDoesNotContain(
-        `test/fixtures/app/dist/js/libraries.js`,
-        'core-js',
-        t
-    );
+    assert.fileDoesNotContain(`test/fixtures/app/dist/js/libraries.js`, 'core-js', t);
 });
 
 test('vendor extraction with no requested JS compilation will throw an error', async t => {
@@ -134,6 +130,55 @@ test('async chunks are placed in the right directory', async t => {
     );
 });
 
+test('custom runtime chunk is put to the public directory by default', async t => {
+    mix.setPublicPath('dist');
+    mix.vue({ version: 2 });
+    mix.js(`test/fixtures/app/src/extract/app.js`, 'js');
+    mix.extract(['lodash'], 'dist/custom/vendor/path/vendor.js');
+
+    await webpack.compile();
+
+    t.true(File.exists(`test/fixtures/app/dist/js/app.js`));
+    t.true(File.exists(`test/fixtures/app/dist/custom/vendor/path/vendor.js`));
+    t.true(File.exists(`test/fixtures/app/dist/manifest.js`));
+
+    assert.manifestEquals(
+        {
+            '/js/app.js': '/js/app.js',
+            '/manifest.js': '/manifest.js',
+            '/custom/vendor/path/vendor.js': '/custom/vendor/path/vendor.js',
+            '/js/split.js': '/js/split.js'
+        },
+        t
+    );
+});
+
+test('custom runtime chunk path can be specified', async t => {
+    mix.vue({ version: 2 });
+    mix.js(`test/fixtures/app/src/extract/app.js`, 'dist/js');
+    mix.extract(['lodash'], 'dist/custom/vendor/path/vendor.js');
+    mix.options({
+        runtimeChunkPath: 'custom/runtime/chunk/path'
+    });
+
+    await webpack.compile();
+
+    t.true(File.exists(`test/fixtures/app/dist/js/app.js`));
+    t.true(File.exists(`test/fixtures/app/dist/custom/vendor/path/vendor.js`));
+    t.true(File.exists(`test/fixtures/app/dist/custom/runtime/chunk/path/manifest.js`));
+
+    assert.manifestEquals(
+        {
+            '/js/app.js': '/js/app.js',
+            '/custom/runtime/chunk/path/manifest.js':
+                '/custom/runtime/chunk/path/manifest.js',
+            '/custom/vendor/path/vendor.js': '/custom/vendor/path/vendor.js',
+            '/js/split.js': '/js/split.js'
+        },
+        t
+    );
+});
+
 test('multiple extractions work', async t => {
     mix.vue({ version: 2 });
     mix.js(`test/fixtures/app/src/extract/app.js`, 'js')
@@ -183,31 +228,19 @@ test.only('configurable extractions work', async t => {
     await webpack.compile();
 
     assert.fileExists(`test/fixtures/app/dist/js/app.js`, t);
-    assert.fileContains(
-        `test/fixtures/app/dist/js/vendor-core-js.js`,
-        'core-js',
-        t
-    );
-    assert.fileContains(
-        `test/fixtures/app/dist/js/vendor-vue-lodash.js`,
-        'vue',
-        t
-    );
-    assert.fileContains(
-        `test/fixtures/app/dist/js/vendor-vue-lodash.js`,
-        'uniq',
-        t
-    );
+    assert.fileContains(`test/fixtures/app/dist/js/vendor-core-js.js`, 'core-js', t);
+    assert.fileContains(`test/fixtures/app/dist/js/vendor-vue-lodash.js`, 'vue', t);
+    assert.fileContains(`test/fixtures/app/dist/js/vendor-vue-lodash.js`, 'uniq', t);
     assert.fileContains(`test/fixtures/app/dist/js/vendor-eol.js`, 'auto', t);
 
     assert.manifestEquals(
         {
             '/js/app.js': '/js/app.js',
-            '/js/manifest.js': '/js/manifest.js',
+            '/js/split.js': '/js/split.js',
             '/js/vendor-core-js.js': '/js/vendor-core-js.js',
             '/js/vendor-eol.js': '/js/vendor-eol.js',
             '/js/vendor-vue-lodash.js': '/js/vendor-vue-lodash.js',
-            '/js/split.js': '/js/split.js'
+            '/manifest.js': '/manifest.js'
         },
         t
     );

--- a/test/features/extraction.js
+++ b/test/features/extraction.js
@@ -15,7 +15,7 @@ test('JS compilation with vendor extraction config', async t => {
 
     await webpack.compile();
 
-    assert.fileExists(`test/fixtures/app/dist/js/manifest.js`, t);
+    assert.fileExists(`test/fixtures/app/dist/manifest.js`, t);
     assert.fileExists(`test/fixtures/app/dist/js/libraries.js`, t);
     assert.fileExists(`test/fixtures/app/dist/js/app.js`, t);
 
@@ -44,7 +44,7 @@ test('JS compilation with vendor extraction with default config', async t => {
 
     await webpack.compile();
 
-    assert.fileExists(`test/fixtures/app/dist/js/manifest.js`, t);
+    assert.fileExists(`test/fixtures/app/dist/manifest.js`, t);
     assert.fileExists(`test/fixtures/app/dist/js/vendor.js`, t);
     assert.fileExists(`test/fixtures/app/dist/js/app.js`, t);
 
@@ -58,7 +58,7 @@ test('JS compilation with total vendor extraction', async t => {
 
     await webpack.compile();
 
-    assert.fileExists(`test/fixtures/app/dist/js/manifest.js`, t);
+    assert.fileExists(`test/fixtures/app/dist/manifest.js`, t);
     assert.fileExists(`test/fixtures/app/dist/js/vendor.js`, t);
     assert.fileExists(`test/fixtures/app/dist/js/app.js`, t);
 
@@ -87,7 +87,7 @@ test('async chunk splitting works', async t => {
     assert.manifestEquals(
         {
             '/js/app.js': '/js/app.js\\?id=\\w{20}',
-            '/js/manifest.js': '/js/manifest.js\\?id=\\w{20}',
+            '/manifest.js': '/manifest.js\\?id=\\w{20}',
             '/js/vendor.js': '/js/vendor.js\\?id=\\w{20}',
             '/js/split.js': '/js/split.js\\?id=\\w{20}'
         },
@@ -122,7 +122,7 @@ test('async chunks are placed in the right directory', async t => {
     assert.manifestEquals(
         {
             '/js/app.js': '/js/app.js',
-            '/js/manifest.js': '/js/manifest.js',
+            '/manifest.js': '/manifest.js',
             '/js/vendor.js': '/js/vendor.js',
             '/js/split.js': '/js/split.js'
         },
@@ -130,33 +130,10 @@ test('async chunks are placed in the right directory', async t => {
     );
 });
 
-test('custom runtime chunk is put to the public directory by default', async t => {
-    mix.setPublicPath('dist');
-    mix.vue({ version: 2 });
-    mix.js(`test/fixtures/app/src/extract/app.js`, 'js');
-    mix.extract(['lodash'], 'dist/custom/vendor/path/vendor.js');
-
-    await webpack.compile();
-
-    t.true(File.exists(`test/fixtures/app/dist/js/app.js`));
-    t.true(File.exists(`test/fixtures/app/dist/custom/vendor/path/vendor.js`));
-    t.true(File.exists(`test/fixtures/app/dist/manifest.js`));
-
-    assert.manifestEquals(
-        {
-            '/js/app.js': '/js/app.js',
-            '/manifest.js': '/manifest.js',
-            '/custom/vendor/path/vendor.js': '/custom/vendor/path/vendor.js',
-            '/js/split.js': '/js/split.js'
-        },
-        t
-    );
-});
-
-test('custom runtime chunk path can be specified', async t => {
+test('custom runtime chunk path can be provided', async t => {
     mix.vue({ version: 2 });
     mix.js(`test/fixtures/app/src/extract/app.js`, 'dist/js');
-    mix.extract(['lodash'], 'dist/custom/vendor/path/vendor.js');
+    mix.extract();
     mix.options({
         runtimeChunkPath: 'custom/runtime/chunk/path'
     });
@@ -164,7 +141,7 @@ test('custom runtime chunk path can be specified', async t => {
     await webpack.compile();
 
     t.true(File.exists(`test/fixtures/app/dist/js/app.js`));
-    t.true(File.exists(`test/fixtures/app/dist/custom/vendor/path/vendor.js`));
+    t.true(File.exists(`test/fixtures/app/dist/js/vendor.js`));
     t.true(File.exists(`test/fixtures/app/dist/custom/runtime/chunk/path/manifest.js`));
 
     assert.manifestEquals(
@@ -172,7 +149,7 @@ test('custom runtime chunk path can be specified', async t => {
             '/js/app.js': '/js/app.js',
             '/custom/runtime/chunk/path/manifest.js':
                 '/custom/runtime/chunk/path/manifest.js',
-            '/custom/vendor/path/vendor.js': '/custom/vendor/path/vendor.js',
+            '/js/vendor.js': '/js/vendor.js',
             '/js/split.js': '/js/split.js'
         },
         t
@@ -198,7 +175,7 @@ test('multiple extractions work', async t => {
     assert.manifestEquals(
         {
             '/js/app.js': '/js/app.js\\?id=\\w{20}',
-            '/js/manifest.js': '/js/manifest.js\\?id=\\w{20}',
+            '/manifest.js': '/manifest.js\\?id=\\w{20}',
             '/js/vendor-core-js.js': '/js/vendor-core-js.js\\?id=\\w{20}',
             '/js/vendor-vue-lodash.js': '/js/vendor-vue-lodash.js\\?id=\\w{20}',
             '/js/split.js': '/js/split.js\\?id=\\w{20}'
@@ -207,7 +184,7 @@ test('multiple extractions work', async t => {
     );
 });
 
-test.only('configurable extractions work', async t => {
+test('configurable extractions work', async t => {
     mix.vue({ version: 2 });
     mix.js(`test/fixtures/app/src/extract/app.js`, 'js');
 

--- a/test/features/mix.js
+++ b/test/features/mix.js
@@ -16,10 +16,7 @@ test('the kitchen sink', async t => {
         .js(`test/fixtures/app/src/js/another.js`, 'js')
         .sass(`test/fixtures/app/src/sass/app.scss`, 'css')
         .postCss(`test/fixtures/app/src/css/app.css`, 'css/example.css')
-        .copy(
-            `test/fixtures/app/dist/js/app.js`,
-            `test/fixtures/app/dist/somewhere`
-        )
+        .copy(`test/fixtures/app/dist/js/app.js`, `test/fixtures/app/dist/somewhere`)
         .scripts(
             [
                 `test/fixtures/app/dist/somewhere/app.js`,
@@ -39,8 +36,8 @@ test('the kitchen sink', async t => {
             '/css/app.css': '/css/app.css\\?id=\\w{20}',
             '/css/example.css': '/css/example.css\\?id=\\w{20}',
             '/js/app.js': '/js/app.js\\?id=\\w{20}',
-            '/js/manifest.js': '/js/manifest.js\\?id=\\w{20}',
             '/js/vendor.js': '/js/vendor.js\\?id=\\w{20}',
+            '/manifest.js': '/manifest.js\\?id=\\w{20}',
             '/somewhere/app.js': '/somewhere/app.js\\?id=\\w{20}',
             '/js/all.js': '/js/all.js\\?id=\\w{20}',
             '/file.js': '/file.js\\?id=\\w{20}'

--- a/upgrade.md
+++ b/upgrade.md
@@ -147,6 +147,52 @@ mix.webpackConfig({
 });
 ```
 
+### Changes to `manifest.js` output path
+
+Previously, the path of the runtime chunk (`manifest.js`) depended on the latest `.js()` call in a chain.
+
+Since Laravel Mix 6 the runtime chunk generates to a public directory.
+
+##### Before
+
+```js
+// webpack.mix.js
+mix.extract(['library-1', 'library-2']);
+mix.js('resources/app.js', 'public/js');
+
+// the `manifest.js` is generated to `public/js`
+```
+
+```js
+// webpack.mix.js
+mix.extract(['library-1', 'library-2']);
+mix.js('resources/app.js', 'public/js');
+mix.js('resources/extra/form.js', 'public/js/extra');
+
+// the `manifest.js` is generated to `public/js/extra`
+```
+
+##### After
+
+```js
+// webpack.mix.js
+mix.extract(['library-1', 'library-2']);
+mix.js('resources/app.js', 'public/js');
+mix.js('resources/extra/form.js', 'public/js/extra');
+
+// the `manifest.js` is generated to `public`
+```
+
+```js
+// webpack.mix.js
+mix.extract(['library-1', 'library-2']);
+mix.js('resources/app.js', 'public/js');
+mix.js('resources/extra/form.js', 'public/js/extra');
+mix.options({ runtimeChunkPath: 'js' });
+
+// the `manifest.js` is generated to `public/js`
+```
+
 # Updates
 
 -   Support for webpack 5


### PR DESCRIPTION
`mix.extract()` creates `vendor.js` & `manifest.js`. While that's possible to specify the directory for the `vendor.js`, that's not possible to do the same for `manifest.js`.

The destination directory for the `manifest.js` is detected automatically. And the current behavior is quite unobvious.

```
mix
  .extract()
  .js('resources/js/app.js', 'public/js')
  .js('resources/js/forms/signup.js', 'public/js/forms');

// `manifest.js` will be stored to the `public/js/forms`
```

```
mix
  .js('resources/js/app.js', 'public/js')
  .extract()
  .js('resources/js/forms/signup.js', 'public/js/forms');

// `manifest.js` will be stored to the `public/js/forms`
```

```
mix
  .js('resources/js/forms/signup.js', 'public/js/forms')
  .extract()
  .js('resources/js/app.js', 'public/js');

// `manifest.js` will be stored to the `public/js`
```

This PR adds an ability to specify the directory for the `manifest.js` explicitly the following way:

```
mix.options({ manifestJsPath: 'js' });
```

Fixes https://github.com/JeffreyWay/laravel-mix/issues/1972 https://github.com/JeffreyWay/laravel-mix/issues/2486