### PR TITLE
Fix typo in HMR script upgrade guide

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -45,7 +45,7 @@ While you're at it, go ahead and switch over to the new Mix CLI.
     "development": "mix",
     "watch": "mix watch",
     "watch-poll": "mix watch -- --watch-options-poll=1000",
-    "hot": "mix --hot",
+    "hot": "mix watch --hot",
     "production": "mix --production"
 }
 ```


### PR DESCRIPTION
Found a small typo in the upgrade guide. :)
https://github.com/JeffreyWay/laravel-mix/blob/78693fc9010d3208f1ee55ef3e828a4465fb8d70/bin/cli.js#L25