### PR TITLE
Fix `ReferenceError: File is not defined at CopyFilesTask.onChange`

### DIFF
--- a/src/tasks/CopyFilesTask.js
+++ b/src/tasks/CopyFilesTask.js
@@ -2,6 +2,7 @@ let Task = require('./Task');
 let FileCollection = require('../FileCollection');
 let Log = require('../Log');
 const path = require('path');
+const File = require('../File');
 
 class CopyFilesTask extends Task {
     /**


### PR DESCRIPTION
This PR fixes this error for the latest Laravel Mix release.

```
[webpack-cli] Promise rejection: ReferenceError: File is not defined
[webpack-cli] ReferenceError: File is not defined
    at CopyFilesTask.onChange (/Users/hivokas/Development/Projects/sandbox/node_modules/laravel-mix/src/tasks/CopyFilesTask.js:32:17)
```