### PR TITLE
Install PostCSS 8.x when running Mix for the first time

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,6 @@
         "lodash": "^4.17.20",
         "md5": "^2.3.0",
         "mini-css-extract-plugin": "^1.1.0",
-        "postcss": "^8.1.2",
         "postcss-load-config": "^3.0.0",
         "postcss-loader": "^4.0.4",
         "style-loader": "^2.0.0",
@@ -111,6 +110,7 @@
         "mock-require": "^3.0.3",
         "normalize.css": "^8.0.1",
         "playwright": "^1.5.1",
+        "postcss": "^8.1.2",
         "postcss-custom-properties": "^10.0.0",
         "prettier": "1.15.2",
         "pretty-quick": "^2.0.1",
@@ -128,6 +128,9 @@
         "vue-template-compiler": "^2.6.12",
         "vue2": "npm:vue@^2.6.12",
         "vue3": "npm:vue@^3.0.1"
+    },
+    "peerDependencies": {
+        "postcss": "^8.1.2"
     },
     "engines": {
         "node": ">=12.14.0"

--- a/src/Dependencies.js
+++ b/src/Dependencies.js
@@ -77,7 +77,7 @@ class Dependencies {
     buildInstallCommand(dependencies) {
         dependencies = dependencies.map(dep => dep.package).join(' ');
 
-        return `npm install ${dependencies} --save-dev --production=false`;
+        return `npm install ${dependencies} --save-dev --production=false --legacy-peer-deps`;
     }
 
     /**

--- a/src/Dependencies.js
+++ b/src/Dependencies.js
@@ -120,9 +120,13 @@ class Dependencies {
             }
         }
 
+        function isValid() {
+            return dep.check ? dep.check(require(name)) : true;
+        }
+
         return {
             ...dep,
-            check: () => isInstalled()
+            check: () => isInstalled() && isValid()
         };
     }
 }

--- a/src/components/CssWebpackConfig.js
+++ b/src/components/CssWebpackConfig.js
@@ -4,6 +4,15 @@ let MiniCssExtractPlugin = require('mini-css-extract-plugin');
 let PostCssPluginsFactory = require('../PostCssPluginsFactory');
 
 class CssWebpackConfig extends AutomaticComponent {
+    dependencies() {
+        return [
+            {
+                package: 'postcss@^8.1',
+                check: postcss => postcss().version.startsWith('8.')
+            }
+        ];
+    }
+
     /**
      * webpack rules to be appended to the master config.
      */

--- a/src/components/CssWebpackConfig.js
+++ b/src/components/CssWebpackConfig.js
@@ -5,6 +5,8 @@ let PostCssPluginsFactory = require('../PostCssPluginsFactory');
 
 class CssWebpackConfig extends AutomaticComponent {
     dependencies() {
+        this.requiresReload = true;
+
         return [
             {
                 package: 'postcss@^8.1',

--- a/test/unit/Dependencies.js
+++ b/test/unit/Dependencies.js
@@ -19,7 +19,7 @@ test('it installs a single dependency', t => {
 
     t.true(
         childProcess.execSync.calledWith(
-            'npm install browser-sync --save-dev --production=false'
+            'npm install browser-sync --save-dev --production=false --legacy-peer-deps'
         )
     );
 });
@@ -29,13 +29,14 @@ test('it installs multiple dependencies', t => {
 
     t.true(
         childProcess.execSync.calledWith(
-            'npm install browser-sync browser-sync-webpack-plugin --save-dev --production=false'
+            'npm install browser-sync browser-sync-webpack-plugin --save-dev --production=false --legacy-peer-deps'
         )
     );
 });
 
 test('it can utilize custom checks for a dependency', t => {
-    const cmd = 'npm install postcss@^8.1 --save-dev --production=false';
+    const cmd =
+        'npm install postcss@^8.1 --save-dev --production=false --legacy-peer-deps';
 
     let called = false;
 

--- a/test/unit/Dependencies.js
+++ b/test/unit/Dependencies.js
@@ -33,3 +33,41 @@ test('it installs multiple dependencies', t => {
         )
     );
 });
+
+test('it can utilize custom checks for a dependency', t => {
+    const cmd = 'npm install postcss@^8.1 --save-dev --production=false';
+
+    let called = false;
+
+    new Dependencies([
+        {
+            package: 'postcss@^8.1',
+            check: () => {
+                called = true;
+
+                return true;
+            }
+        }
+    ]).install(false);
+
+    t.true(called);
+    t.false(childProcess.execSync.calledWith(cmd));
+
+    called = false;
+
+    new Dependencies([
+        {
+            package: 'postcss@^8.1',
+            check: postcss => {
+                called = true;
+
+                t.true(postcss().version.startsWith('8.1'));
+
+                return false;
+            }
+        }
+    ]).install(false);
+
+    t.true(called);
+    t.true(childProcess.execSync.calledWith(cmd));
+});

--- a/test/unit/Dependencies.js
+++ b/test/unit/Dependencies.js
@@ -15,7 +15,7 @@ test.afterEach.always(() => {
 });
 
 test('it installs a single dependency', t => {
-    new Dependencies(['browser-sync']).install(false, true);
+    new Dependencies(['browser-sync']).install(false);
 
     t.true(
         childProcess.execSync.calledWith(
@@ -25,10 +25,7 @@ test('it installs a single dependency', t => {
 });
 
 test('it installs multiple dependencies', t => {
-    new Dependencies(['browser-sync', 'browser-sync-webpack-plugin']).install(
-        false,
-        true
-    );
+    new Dependencies(['browser-sync', 'browser-sync-webpack-plugin']).install(false);
 
     t.true(
         childProcess.execSync.calledWith(


### PR DESCRIPTION
This installs PostCSS 8 into the user's root package.json after first run of Mix. This should, hopefully, squash most / all those weird PostCSS problems we're having.