### PR TITLE
Allow passing loader options via mix.vue

### DIFF
--- a/src/components/Vue.js
+++ b/src/components/Vue.js
@@ -52,9 +52,7 @@ class Vue {
 
         let dependencies = [
             this.version === 2 ? 'vue-template-compiler' : '@vue/compiler-sfc',
-            this.version === 2
-                ? 'vue-loader@^15.9.1'
-                : 'vue-loader@^16.0.0-beta.8'
+            this.version === 2 ? 'vue-loader@^15.9.5' : 'vue-loader@^16.0.0-beta.9'
         ];
 
         if (this.options.extractStyles && this.options.globalStyles) {

--- a/src/components/Vue.js
+++ b/src/components/Vue.js
@@ -3,6 +3,8 @@ let File = require('../File');
 let VueVersion = require('../VueVersion');
 let AppendVueStylesPlugin = require('../webpackPlugins/Css/AppendVueStylesPlugin');
 
+/** @typedef {import("vue").VueLoaderOptions} VueLoaderOptions */
+
 class Vue {
     /**
      * Create a new component instance.
@@ -18,6 +20,7 @@ class Vue {
      * @param {number} [options.version] Which version of Vue to support. Detected automatically if not given.
      * @param {string|null} [options.globalStyles] A file to include w/ every vue style block.
      * @param {boolean|string} [options.extractStyles] Whether or not to extract vue styles. If given a string the name of the file to extract to.
+     * @param {VueLoaderOptions} [options.options] Options to pass to Vue Loader
      */
     register(options = {}) {
         if (
@@ -34,6 +37,7 @@ class Vue {
 
         this.options = Object.assign(
             {
+                options: null,
                 globalStyles: null,
                 extractStyles: false
             },
@@ -74,7 +78,7 @@ class Vue {
             use: [
                 {
                     loader: 'vue-loader',
-                    options: Config.vue || {}
+                    options: this.options.options || Config.vue || {}
                 }
             ]
         });

--- a/src/config.js
+++ b/src/config.js
@@ -190,6 +190,15 @@ module.exports = function() {
         clearConsole: true,
 
         /**
+         * Options to pass to vue-loader
+         *
+         * @deprecated Use `.vue({options: {…}})` instead
+         *
+         * @type {any}
+         */
+        vue: {},
+
+        /**
          * Merge the given options with the current defaults.
          *
          * @param {object} options

--- a/test/features/vue.js
+++ b/test/features/vue.js
@@ -24,10 +24,7 @@ test('non-feature-flag use of mix.vue throws an error', t => {
 test('it adds the Vue 2 runtime resolve alias', t => {
     mix.vue({ version: 2, runtimeOnly: true });
 
-    t.is(
-        'vue/dist/vue.runtime.esm.js',
-        webpack.buildConfig().resolve.alias.vue$
-    );
+    t.is('vue/dist/vue.runtime.esm.js', webpack.buildConfig().resolve.alias.vue$);
 });
 
 test('it knows the Vue 2 compiler name', t => {
@@ -40,10 +37,10 @@ test('it knows the Vue 2 compiler name', t => {
 
 test('it appends vue styles to your sass compiled file', async t => {
     mix.vue({ version: 2, extractStyles: true });
-    mix.js(
-        `test/fixtures/app/src/vue/app-with-vue-and-scss.js`,
-        'js/app.js'
-    ).sass(`test/fixtures/app/src/sass/app.scss`, 'css/app.css');
+    mix.js(`test/fixtures/app/src/vue/app-with-vue-and-scss.js`, 'js/app.js').sass(
+        `test/fixtures/app/src/sass/app.scss`,
+        'css/app.css'
+    );
 
     await webpack.compile();
 
@@ -65,10 +62,10 @@ test('it appends vue styles to your sass compiled file', async t => {
 
 test('it appends vue styles to your less compiled file', async t => {
     mix.vue({ version: 2, extractStyles: true });
-    mix.js(
-        `test/fixtures/app/src/vue/app-with-vue-and-scss.js`,
-        'js/app.js'
-    ).less(`test/fixtures/app/src/less/main.less`, 'css/app.css');
+    mix.js(`test/fixtures/app/src/vue/app-with-vue-and-scss.js`, 'js/app.js').less(
+        `test/fixtures/app/src/less/main.less`,
+        'css/app.css'
+    );
 
     await webpack.compile();
 
@@ -100,10 +97,7 @@ test('it appends vue styles to a vue-styles.css file, if no preprocessor is used
 }
 `;
 
-    t.is(
-        expected,
-        File.find(`test/fixtures/app/dist/css/vue-styles.css`).read()
-    );
+    t.is(expected, File.find(`test/fixtures/app/dist/css/vue-styles.css`).read());
 });
 
 test('it extracts vue vanilla CSS styles to a dedicated file', async t => {
@@ -121,10 +115,7 @@ test('it extracts vue vanilla CSS styles to a dedicated file', async t => {
 
 `;
 
-    t.is(
-        expected,
-        File.find(`test/fixtures/app/dist/css/components.css`).read()
-    );
+    t.is(expected, File.find(`test/fixtures/app/dist/css/components.css`).read());
 });
 
 test('it extracts vue Stylus styles to a dedicated file', async t => {
@@ -141,10 +132,7 @@ test('it extracts vue Stylus styles to a dedicated file', async t => {
 
 `;
 
-    t.is(
-        expected,
-        File.find(`test/fixtures/app/dist/css/components.css`).read()
-    );
+    t.is(expected, File.find(`test/fixtures/app/dist/css/components.css`).read());
 });
 
 test('it does also add the vue webpack rules with typescript component', t => {
@@ -160,10 +148,10 @@ test('it does also add the vue webpack rules with typescript component', t => {
 
 test('it extracts vue .scss styles to a dedicated file', async t => {
     mix.vue({ version: 2, extractStyles: 'css/components.css' });
-    mix.js(
-        `test/fixtures/app/src/vue/app-with-vue-and-scss.js`,
-        'js/app.js'
-    ).sass(`test/fixtures/app/src/sass/app.scss`, 'css/app.css');
+    mix.js(`test/fixtures/app/src/vue/app-with-vue-and-scss.js`, 'js/app.js').sass(
+        `test/fixtures/app/src/sass/app.scss`,
+        'css/app.css'
+    );
 
     await webpack.compile();
 
@@ -185,11 +173,7 @@ test('it extracts vue .scss styles to a dedicated file', async t => {
 }
 `;
 
-    assert.fileMatchesCss(
-        `test/fixtures/app/dist/css/components.css`,
-        expected,
-        t
-    );
+    assert.fileMatchesCss(`test/fixtures/app/dist/css/components.css`, expected, t);
 });
 
 test('it extracts vue .sass styles to a dedicated file', async t => {
@@ -219,11 +203,7 @@ test('it extracts vue .sass styles to a dedicated file', async t => {
 }
 `;
 
-    assert.fileMatchesCss(
-        `test/fixtures/app/dist/css/components.css`,
-        expected,
-        t
-    );
+    assert.fileMatchesCss(`test/fixtures/app/dist/css/components.css`, expected, t);
 });
 
 test('it extracts vue PostCSS styles to a dedicated file', async t => {
@@ -234,10 +214,7 @@ test('it extracts vue PostCSS styles to a dedicated file', async t => {
 
     // When we compile Vue...
     mix.vue({ version: 2, extractStyles: 'css/components.css' });
-    mix.js(
-        `test/fixtures/app/src/vue/app-with-vue-and-postcss.js`,
-        'js/app.js'
-    );
+    mix.js(`test/fixtures/app/src/vue/app-with-vue-and-postcss.js`, 'js/app.js');
 
     await webpack.compile();
 
@@ -253,10 +230,7 @@ test('it extracts vue PostCSS styles to a dedicated file', async t => {
 
 `;
 
-    t.is(
-        expected,
-        File.find(`test/fixtures/app/dist/css/components.css`).read()
-    );
+    t.is(expected, File.find(`test/fixtures/app/dist/css/components.css`).read());
 
     // Clean up.
     postCssConfigFile.delete();
@@ -276,10 +250,7 @@ test('it extracts vue Less styles to a dedicated file', async t => {
 
 `;
 
-    t.is(
-        expected,
-        File.find(`test/fixtures/app/dist/css/components.css`).read()
-    );
+    t.is(expected, File.find(`test/fixtures/app/dist/css/components.css`).read());
 });
 
 test('it supports global Vue styles for sass', async t => {
@@ -299,10 +270,7 @@ test('it supports global Vue styles for sass', async t => {
             stylus: [`test/fixtures/app/src/stylus/global.styl`]
         }
     });
-    mix.js(
-        `test/fixtures/app/src/vue/app-with-vue-and-global-styles.js`,
-        'js/app.js'
-    );
+    mix.js(`test/fixtures/app/src/vue/app-with-vue-and-global-styles.js`, 'js/app.js');
     mix.sass(`test/fixtures/app/src/sass/app.scss`, 'css/app.css');
 
     await webpack.compile();
@@ -343,3 +311,59 @@ test('it supports global Vue styles for sass', async t => {
 
     postCssConfigFile.delete();
 });
+
+test('Vue-loader options via mix.options.vue', async t => {
+    const compiler = compilerSpy();
+
+    mix.vue({ version: 2 });
+    mix.options({ vue: { compiler } });
+
+    mix.js(`test/fixtures/app/src/vue/app-with-vue-and-css.js`, 'js/app.js');
+
+    await webpack.compile();
+
+    t.truthy(compiler.called);
+
+    t.true(File.exists(`test/fixtures/app/dist/js/app.js`));
+});
+
+test('Vue-loader options via mix.vue', async t => {
+    const compiler = compilerSpy();
+
+    mix.vue({
+        version: 2,
+        options: { compiler }
+    });
+
+    mix.js(`test/fixtures/app/src/vue/app-with-vue-and-css.js`, 'js/app.js');
+
+    await webpack.compile();
+
+    t.true(compiler.called);
+
+    t.true(File.exists(`test/fixtures/app/dist/js/app.js`));
+});
+
+function compilerSpy() {
+    const compiler = require('vue-template-compiler');
+    let called = false;
+
+    // We don't use sinon.spy here because if you create a spy of
+    // `require("vue-template-compiler")` it will always be true
+    // as that modifies the global object that's used by default.
+    // Since we want to ensure that passing loader options works
+    // we need to do that by ensuring our "custom" compiler is used
+    return {
+        ...compiler,
+
+        compile(...args) {
+            called = true;
+
+            return compiler.compile(...args);
+        },
+
+        get called() {
+            return called;
+        }
+    };
+}

--- a/test/features/vue3.js
+++ b/test/features/vue3.js
@@ -14,19 +14,13 @@ test.beforeEach(() => {
 test('it adds the Vue 3 resolve alias', t => {
     mix.vue({ version: 3, extractStyles: true });
 
-    t.is(
-        'vue/dist/vue.esm-bundler.js',
-        webpack.buildConfig().resolve.alias.vue$
-    );
+    t.is('vue/dist/vue.esm-bundler.js', webpack.buildConfig().resolve.alias.vue$);
 });
 
 test('it adds the Vue 3 runtime resolve alias', t => {
     mix.vue({ version: 3, runtimeOnly: true });
 
-    t.is(
-        'vue/dist/vue.runtime.esm-bundler.js',
-        webpack.buildConfig().resolve.alias.vue$
-    );
+    t.is('vue/dist/vue.runtime.esm-bundler.js', webpack.buildConfig().resolve.alias.vue$);
 });
 
 test('it knows the Vue 3 compiler name', t => {
@@ -40,10 +34,10 @@ test('it knows the Vue 3 compiler name', t => {
 test('it appends vue styles to your sass compiled file', async t => {
     mix.vue({ version: 3, extractStyles: true });
 
-    mix.js(
-        `test/fixtures/app/src/vue3/app-with-vue-and-scss.js`,
-        'js/app.js'
-    ).sass(`test/fixtures/app/src/sass/app.scss`, 'css/app.css');
+    mix.js(`test/fixtures/app/src/vue3/app-with-vue-and-scss.js`, 'js/app.js').sass(
+        `test/fixtures/app/src/sass/app.scss`,
+        'css/app.css'
+    );
 
     await webpack.compile();
 
@@ -65,10 +59,10 @@ test('it appends vue styles to your sass compiled file', async t => {
 
 test('it appends vue styles to your less compiled file', async t => {
     mix.vue({ version: 3, extractStyles: true });
-    mix.js(
-        `test/fixtures/app/src/vue3/app-with-vue-and-scss.js`,
-        'js/app.js'
-    ).less(`test/fixtures/app/src/less/main.less`, 'css/app.css');
+    mix.js(`test/fixtures/app/src/vue3/app-with-vue-and-scss.js`, 'js/app.js').less(
+        `test/fixtures/app/src/less/main.less`,
+        'css/app.css'
+    );
 
     await webpack.compile();
 
@@ -101,10 +95,7 @@ test('it appends vue styles to a vue-styles.css file, if no preprocessor is used
 }
 `;
 
-    t.is(
-        expected,
-        File.find(`test/fixtures/app/dist/css/vue-styles.css`).read()
-    );
+    t.is(expected, File.find(`test/fixtures/app/dist/css/vue-styles.css`).read());
 });
 
 test('it extracts vue vanilla CSS styles to a dedicated file', async t => {
@@ -122,18 +113,12 @@ test('it extracts vue vanilla CSS styles to a dedicated file', async t => {
 
 `;
 
-    t.is(
-        expected,
-        File.find(`test/fixtures/app/dist/css/components.css`).read()
-    );
+    t.is(expected, File.find(`test/fixtures/app/dist/css/components.css`).read());
 });
 
 test('it extracts vue Stylus styles to a dedicated file', async t => {
     mix.vue({ version: 3, extractStyles: 'css/components.css' });
-    mix.js(
-        `test/fixtures/app/src/vue3/app-with-vue-and-stylus.js`,
-        'js/app.js'
-    );
+    mix.js(`test/fixtures/app/src/vue3/app-with-vue-and-stylus.js`, 'js/app.js');
 
     await webpack.compile();
 
@@ -145,10 +130,7 @@ test('it extracts vue Stylus styles to a dedicated file', async t => {
 
 `;
 
-    t.is(
-        expected,
-        File.find(`test/fixtures/app/dist/css/components.css`).read()
-    );
+    t.is(expected, File.find(`test/fixtures/app/dist/css/components.css`).read());
 });
 
 test('it does also add the vue webpack rules with typescript component', t => {
@@ -164,10 +146,10 @@ test('it does also add the vue webpack rules with typescript component', t => {
 
 test('it extracts vue .scss styles to a dedicated file', async t => {
     mix.vue({ version: 3, extractStyles: 'css/components.css' });
-    mix.js(
-        `test/fixtures/app/src/vue3/app-with-vue-and-scss.js`,
-        'js/app.js'
-    ).sass(`test/fixtures/app/src/sass/app.scss`, 'css/app.css');
+    mix.js(`test/fixtures/app/src/vue3/app-with-vue-and-scss.js`, 'js/app.js').sass(
+        `test/fixtures/app/src/sass/app.scss`,
+        'css/app.css'
+    );
 
     await webpack.compile();
 
@@ -189,11 +171,7 @@ test('it extracts vue .scss styles to a dedicated file', async t => {
 }
 `;
 
-    assert.fileMatchesCss(
-        `test/fixtures/app/dist/css/components.css`,
-        expected,
-        t
-    );
+    assert.fileMatchesCss(`test/fixtures/app/dist/css/components.css`, expected, t);
 });
 
 test('it extracts vue .sass styles to a dedicated file', async t => {
@@ -223,11 +201,7 @@ test('it extracts vue .sass styles to a dedicated file', async t => {
 }
 `;
 
-    assert.fileMatchesCss(
-        `test/fixtures/app/dist/css/components.css`,
-        expected,
-        t
-    );
+    assert.fileMatchesCss(`test/fixtures/app/dist/css/components.css`, expected, t);
 });
 
 test('it extracts vue PostCSS styles to a dedicated file', async t => {
@@ -237,10 +211,7 @@ test('it extracts vue PostCSS styles to a dedicated file', async t => {
     );
 
     mix.vue({ version: 3, extractStyles: 'css/components.css' });
-    mix.js(
-        `test/fixtures/app/src/vue3/app-with-vue-and-postcss.js`,
-        'js/app.js'
-    );
+    mix.js(`test/fixtures/app/src/vue3/app-with-vue-and-postcss.js`, 'js/app.js');
 
     await webpack.compile();
 
@@ -256,10 +227,7 @@ test('it extracts vue PostCSS styles to a dedicated file', async t => {
 
 `;
 
-    t.is(
-        expected,
-        File.find(`test/fixtures/app/dist/css/components.css`).read()
-    );
+    t.is(expected, File.find(`test/fixtures/app/dist/css/components.css`).read());
 
     // Clean up
     postCssConfigFile.delete();
@@ -279,10 +247,7 @@ test('it extracts vue Less styles to a dedicated file', async t => {
 
 `;
 
-    t.is(
-        expected,
-        File.find(`test/fixtures/app/dist/css/components.css`).read()
-    );
+    t.is(expected, File.find(`test/fixtures/app/dist/css/components.css`).read());
 });
 
 test('it supports global Vue styles for sass', async t => {
@@ -302,10 +267,7 @@ test('it supports global Vue styles for sass', async t => {
             stylus: [`test/fixtures/app/src/stylus/global.styl`]
         }
     });
-    mix.js(
-        `test/fixtures/app/src/vue3/app-with-vue-and-global-styles.js`,
-        'js/app.js'
-    );
+    mix.js(`test/fixtures/app/src/vue3/app-with-vue-and-global-styles.js`, 'js/app.js');
     mix.sass(`test/fixtures/app/src/sass/app.scss`, 'css/app.css');
 
     await webpack.compile();
@@ -346,3 +308,59 @@ test('it supports global Vue styles for sass', async t => {
 
     postCssConfigFile.delete();
 });
+
+test('Vue-loader options via mix.options.vue', async t => {
+    const compiler = compilerSpy();
+
+    mix.vue({ version: 3 });
+    mix.options({ vue: { compiler } });
+
+    mix.js(`test/fixtures/app/src/vue/app-with-vue-and-css.js`, 'js/app.js');
+
+    await webpack.compile();
+
+    t.truthy(compiler.called);
+
+    t.true(File.exists(`test/fixtures/app/dist/js/app.js`));
+});
+
+test('Vue-loader options via mix.vue', async t => {
+    const compiler = compilerSpy();
+
+    mix.vue({
+        version: 3,
+        options: { compiler }
+    });
+
+    mix.js(`test/fixtures/app/src/vue/app-with-vue-and-css.js`, 'js/app.js');
+
+    await webpack.compile();
+
+    t.true(compiler.called);
+
+    t.true(File.exists(`test/fixtures/app/dist/js/app.js`));
+});
+
+function compilerSpy() {
+    const compiler = require('@vue/compiler-dom');
+    let called = false;
+
+    // We don't use sinon.spy here because if you create a spy of
+    // `require("@vue/compiler-dom")` it will always be true
+    // as that modifies the global object that's used by default.
+    // Since we want to ensure that passing loader options works
+    // we need to do that by ensuring our "custom" compiler is used
+    return {
+        ...compiler,
+
+        compile(...args) {
+            called = true;
+
+            return compiler.compile(...args);
+        },
+
+        get called() {
+            return called;
+        }
+    };
+}

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -15,6 +15,7 @@ import { TransformOptions as BabelConfig } from 'babel-core';
 import { Options as BrowserSyncConfig } from 'browser-sync';
 import { TerserPluginOptions } from 'terser-webpack-plugin';
 import * as ExtractTypes from './extract';
+import { VueLoaderOptions } from 'vue-loader';
 
 interface MixConfig {
     production?: boolean;
@@ -54,6 +55,8 @@ interface MixConfig {
     webpackConfig?: webpack.Configuration;
     babelConfig?: BabelConfig;
     clearConsole?: boolean;
+    /** @deprecated Use `mix.vue({options: {…}})` instead */
+    vue?: any;
     merge?: (options: MixConfig) => void;
 }
 
@@ -76,20 +79,13 @@ declare module 'laravel-mix' {
             name: string,
             component:
                 | Component
-                | ((
-                      mix: Api,
-                      config: webpack.Configuration,
-                      ...args: any[]
-                  ) => void)
+                | ((mix: Api, config: webpack.Configuration, ...args: any[]) => void)
         ) => Api;
         type Extract =
             | ((output?: string) => Api)
             | ((libs: string[], output?: string) => Api)
             | ((test: ExtractTypes.ExtractTestCallback, output?: string) => Api)
-            | ((
-                  config: Partial<ExtractTypes.Extraction>,
-                  output?: string
-              ) => Api);
+            | ((config: Partial<ExtractTypes.Extraction>, output?: string) => Api);
         type Notifications = () => Api;
         type Version = (files?: string | string[]) => Api;
 
@@ -112,11 +108,7 @@ declare module 'laravel-mix' {
         type Typescript = Javascript;
 
         // File-related
-        type Combine = (
-            src: string | string[],
-            output?: string,
-            babel?: boolean
-        ) => Api;
+        type Combine = (src: string | string[], output?: string, babel?: boolean) => Api;
         type Babel = Combine;
         type Minify = Combine;
         type Scripts = Combine;
@@ -130,6 +122,7 @@ declare module 'laravel-mix' {
         type React = () => Api;
         type Vue = (
             options: {
+                options: VueLoaderOptions;
                 version: number;
                 extractStyles?: boolean;
                 globalStyles?:


### PR DESCRIPTION
Right now user's can pass vue-loader options using `mix.options({ vue: { … } })`. With the move to `mix.vue()` it's more appropriate to allow passing those via `mix.vue({ options: { … } })`

This PR allows passing vue-loader options like this:
```js
mix.vue({
  version: 2,
  options: {
    compilerOptions: {
      preserveWhitespace: true
    }
  }
})
```

It will fallback to using the loader options defined by `mix.options(…)` for backwards compatibility purposes.