### PR TITLE
Quote paths when building CLI script command.

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -87,10 +87,12 @@ function commandScript(cmd, opts) {
  */
 function commandArgs(args) {
     return args.map(arg => {
-        const keyValue = arg.split('=');
+        // Split string at first = only
+        const pattern = /^([^=]+)=(.*)$/;
+        const keyValue = arg.includes('=') ? pattern.exec(arg).slice(1) : [];
 
-        if (typeof keyValue[1] !== 'undefined') {
-            arg = `${keyValue[0]}="${keyValue[1]}"`;
+        if (keyValue.length === 2) {
+            return `${keyValue[0]}="${keyValue[1]}"`;
         }
 
         return arg;

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -48,9 +48,9 @@ async function run() {
 async function executeScript(cmd, opts, args = []) {
     let script = [
         `cross-env NODE_ENV=${opts.production ? 'production' : 'development'}`,
-        `MIX_FILE=${opts.mixConfig}`,
+        `MIX_FILE="${opts.mixConfig}"`,
         commandScript(cmd, opts),
-        `--config=${require.resolve('../setup/webpack.config.js')}`,
+        `--config="${require.resolve('../setup/webpack.config.js')}"`,
         ...args
     ].join(' ');
 

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -51,7 +51,7 @@ async function executeScript(cmd, opts, args = []) {
         `MIX_FILE="${opts.mixConfig}"`,
         commandScript(cmd, opts),
         `--config="${require.resolve('../setup/webpack.config.js')}"`,
-        commandArgs(args)
+        ...commandArgs(args)
     ].join(' ');
 
     if (process.env.TESTING) {
@@ -86,15 +86,13 @@ function commandScript(cmd, opts) {
  * @param {string[]} args
  */
 function commandArgs(args) {
-    return args
-        .map(arg => {
-            const keyValue = arg.split('=');
+    return args.map(arg => {
+        const keyValue = arg.split('=');
 
-            if (typeof keyValue[1] !== 'undefined') {
-                arg = `${keyValue[0]}="${keyValue[1]}"`;
-            }
+        if (typeof keyValue[1] !== 'undefined') {
+            arg = `${keyValue[0]}="${keyValue[1]}"`;
+        }
 
-            return arg;
-        })
-        .join(' ');
+        return arg;
+    });
 }

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -51,7 +51,7 @@ async function executeScript(cmd, opts, args = []) {
         `MIX_FILE="${opts.mixConfig}"`,
         commandScript(cmd, opts),
         `--config="${require.resolve('../setup/webpack.config.js')}"`,
-        ...args
+        commandArgs(args)
     ].join(' ');
 
     if (process.env.TESTING) {
@@ -78,4 +78,23 @@ function commandScript(cmd, opts) {
     } else if (cmd === 'watch' && opts.hot) {
         return 'npx webpack serve --hot --inline --disable-host-check';
     }
+}
+
+/**
+ * Get the command arguments with quoted values.
+ *
+ * @param {array} args
+ */
+function commandArgs(args) {
+    return args
+        .map(arg => {
+            const keyValue = arg.split('=');
+
+            if (typeof keyValue[1] !== 'undefined') {
+                arg = `${keyValue[0]}="${keyValue[1]}"`;
+            }
+
+            return arg;
+        })
+        .join(' ');
 }

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -83,7 +83,7 @@ function commandScript(cmd, opts) {
 /**
  * Get the command arguments with quoted values.
  *
- * @param {array} args
+ * @param {string[]} args
  */
 function commandArgs(args) {
     return args

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -51,7 +51,7 @@ async function executeScript(cmd, opts, args = []) {
         `MIX_FILE="${opts.mixConfig}"`,
         commandScript(cmd, opts),
         `--config="${require.resolve('../setup/webpack.config.js')}"`,
-        ...commandArgs(args)
+        ...quoteArgs(args)
     ].join(' ');
 
     if (process.env.TESTING) {
@@ -85,7 +85,7 @@ function commandScript(cmd, opts) {
  *
  * @param {string[]} args
  */
-function commandArgs(args) {
+function quoteArgs(args) {
     return args.map(arg => {
         // Split string at first = only
         const pattern = /^([^=]+)=(.*)$/;

--- a/test/unit/cli.js
+++ b/test/unit/cli.js
@@ -86,3 +86,15 @@ test('it calls webpack with hot reloading using polling', async t => {
         stdout
     );
 });
+
+test('it calls webpack with quoted key value pair command arguments', async t => {
+    let { stdout } = await mix(['--', '--env', 'foo="bar baz"']);
+
+    t.is(
+        'cross-env NODE_ENV=development MIX_FILE="webpack.mix" npx webpack --progress --config="' +
+            require.resolve('../../setup/webpack.config.js') +
+            '"',
+        ' --env foo="bar baz"',
+        stdout
+    );
+});

--- a/test/unit/cli.js
+++ b/test/unit/cli.js
@@ -88,13 +88,13 @@ test('it calls webpack with hot reloading using polling', async t => {
 });
 
 test('it calls webpack with quoted key value pair command arguments', async t => {
-    let { stdout } = await mix(['--', '--env', 'foo="bar baz"']);
+    let { stdout } = await mix(['--', '--env', 'foo="bar baz"', 'foo="bar=baz"']);
 
     t.is(
         'cross-env NODE_ENV=development MIX_FILE="webpack.mix" npx webpack --progress --config="' +
             require.resolve('../../setup/webpack.config.js') +
             '"' +
-            ' --env foo="bar baz"',
+            ' --env foo="bar baz" foo="bar=baz"',
         stdout
     );
 });

--- a/test/unit/cli.js
+++ b/test/unit/cli.js
@@ -93,8 +93,8 @@ test('it calls webpack with quoted key value pair command arguments', async t =>
     t.is(
         'cross-env NODE_ENV=development MIX_FILE="webpack.mix" npx webpack --progress --config="' +
             require.resolve('../../setup/webpack.config.js') +
-            '"',
-        ' --env foo="bar baz"',
+            '"' +
+            ' --env foo="bar baz"',
         stdout
     );
 });

--- a/test/unit/cli.js
+++ b/test/unit/cli.js
@@ -5,9 +5,7 @@ import path from 'path';
 function mix(args = []) {
     return new Promise(resolve => {
         exec(
-            `cross-env TESTING=true node ${path.resolve(
-                './bin/cli'
-            )} ${args.join(' ')}`,
+            `cross-env TESTING=true node ${path.resolve('./bin/cli')} ${args.join(' ')}`,
             { cwd: '.' },
             (error, stdout, stderr) => {
                 resolve({
@@ -25,8 +23,9 @@ test('it calls webpack in development mode', async t => {
     let { stdout } = await mix();
 
     t.is(
-        'cross-env NODE_ENV=development MIX_FILE=webpack.mix npx webpack --progress --config=' +
-            require.resolve('../../setup/webpack.config.js'),
+        'cross-env NODE_ENV=development MIX_FILE="webpack.mix" npx webpack --progress --config="' +
+            require.resolve('../../setup/webpack.config.js') +
+            '"',
         stdout
     );
 });
@@ -35,8 +34,9 @@ test('it calls webpack in production mode', async t => {
     let { stdout } = await mix(['--production']);
 
     t.is(
-        'cross-env NODE_ENV=production MIX_FILE=webpack.mix npx webpack --progress --config=' +
-            require.resolve('../../setup/webpack.config.js'),
+        'cross-env NODE_ENV=production MIX_FILE="webpack.mix" npx webpack --progress --config="' +
+            require.resolve('../../setup/webpack.config.js') +
+            '"',
         stdout
     );
 });
@@ -45,8 +45,9 @@ test('it calls webpack with watch mode', async t => {
     let { stdout } = await mix(['watch']);
 
     t.is(
-        'cross-env NODE_ENV=development MIX_FILE=webpack.mix npx webpack --progress --watch --config=' +
-            require.resolve('../../setup/webpack.config.js'),
+        'cross-env NODE_ENV=development MIX_FILE="webpack.mix" npx webpack --progress --watch --config="' +
+            require.resolve('../../setup/webpack.config.js') +
+            '"',
         stdout
     );
 });
@@ -55,8 +56,9 @@ test('it calls webpack with watch mode using polling', async t => {
     let { stdout } = await mix(['watch', '--', '--watch-poll']);
 
     t.is(
-        'cross-env NODE_ENV=development MIX_FILE=webpack.mix npx webpack --progress --watch --config=' +
+        'cross-env NODE_ENV=development MIX_FILE="webpack.mix" npx webpack --progress --watch --config="' +
             require.resolve('../../setup/webpack.config.js') +
+            '"' +
             ' --watch-poll',
         stdout
     );
@@ -66,8 +68,9 @@ test('it calls webpack with hot reloading', async t => {
     let { stdout } = await mix(['watch', '--hot']);
 
     t.is(
-        'cross-env NODE_ENV=development MIX_FILE=webpack.mix npx webpack serve --hot --inline --disable-host-check --config=' +
-            require.resolve('../../setup/webpack.config.js'),
+        'cross-env NODE_ENV=development MIX_FILE="webpack.mix" npx webpack serve --hot --inline --disable-host-check --config="' +
+            require.resolve('../../setup/webpack.config.js') +
+            '"',
         stdout
     );
 });
@@ -76,8 +79,9 @@ test('it calls webpack with hot reloading using polling', async t => {
     let { stdout } = await mix(['watch', '--hot', '--', '--watch-poll']);
 
     t.is(
-        'cross-env NODE_ENV=development MIX_FILE=webpack.mix npx webpack serve --hot --inline --disable-host-check --config=' +
+        'cross-env NODE_ENV=development MIX_FILE="webpack.mix" npx webpack serve --hot --inline --disable-host-check --config="' +
             require.resolve('../../setup/webpack.config.js') +
+            '"' +
             ' --watch-poll',
         stdout
     );


### PR DESCRIPTION
Fixes #2621 

Make sure paths are quoted when building the CLI script command in case any paths contain spaces.