### PR TITLE
[React] add support to new JSX transform

### DIFF
--- a/src/components/React.js
+++ b/src/components/React.js
@@ -23,7 +23,7 @@ class React {
      */
     babelConfig() {
         return {
-            presets: ['@babel/preset-react']
+            presets: [['@babel/preset-react', { runtime: 'automatic' }]]
         };
     }
 }

--- a/test/features/react.js
+++ b/test/features/react.js
@@ -49,7 +49,7 @@ test('it sets the babel config correctly', async t => {
 
     t.true(
         Config.babel().presets.find(p =>
-            p.includes(path.normalize('@babel/preset-react'))
+            p[0].includes(path.normalize('@babel/preset-react'))
         ) !== undefined
     );
 });


### PR DESCRIPTION
- With the new transform, you can use JSX without importing React.
- Depending on your setup, its compiled output may slightly improve the bundle size.

Additional information can be found here:

- [Reactjs.org](https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html)
- [Babel](https://babeljs.io/blog/2020/03/16/7.9.0)