### PR TITLE
Refactor test to check the PostCSS version

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
         "mini-css-extract-plugin": "^1.1.0",
         "postcss-load-config": "^3.0.0",
         "postcss-loader": "^4.0.4",
+        "semver": "^5.7.1",
         "style-loader": "^2.0.0",
         "terser": "^5.3.7",
         "terser-webpack-plugin": "^5.0.0",

--- a/src/components/CssWebpackConfig.js
+++ b/src/components/CssWebpackConfig.js
@@ -10,7 +10,7 @@ class CssWebpackConfig extends AutomaticComponent {
         return [
             {
                 package: 'postcss@^8.1',
-                check: postcss => postcss().version.startsWith('8.')
+                check: postcss => semver.satisfies(postcss().version, '^8.1')
             }
         ];
     }

--- a/test/unit/Dependencies.js
+++ b/test/unit/Dependencies.js
@@ -2,6 +2,7 @@ import '../../src/helpers';
 import test from 'ava';
 import childProcess from 'child_process';
 import sinon from 'sinon';
+import semver from 'semver';
 import Dependencies from '../../src/Dependencies';
 import PackageManager from '../../src/PackageManager';
 
@@ -72,7 +73,7 @@ test('it can utilize custom checks for a dependency', t => {
             check: postcss => {
                 called = true;
 
-                t.true(postcss().version.startsWith('8.1'));
+                t.true(semver.satisfies(postcss().version, '^8.1'));
 
                 return false;
             }


### PR DESCRIPTION
PostCSS 8.2 has been released, so using String.prototype.startsWith() throws an error.
This PR resolves the problem.

## Reference
https://github.com/postcss/postcss/releases/tag/8.2.0