### PR TITLE
Change @next to @latest in upgrade guide

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -11,7 +11,7 @@
 -   [Did We Miss Something?](#did-we-miss-something)
 
 ```bash
-npm install laravel-mix@next
+npm install laravel-mix@latest
 ```
 
 ### Review Your Dependencies


### PR DESCRIPTION
Updates `@next` to `@latest` in the upgrade guide since v6 is the official tag now.