### PR TITLE
Only check filename part.

### DIFF
--- a/src/PackageManager.js
+++ b/src/PackageManager.js
@@ -1,12 +1,21 @@
+const File = require('./File');
+const Paths = require('./Paths');
+
 class PackageManager {
     static detect() {
         const execPath = process.env.npm_execpath || '';
 
-        if (execPath.endsWith('yarn.js')) {
+        if (execPath.endsWith('yarn.js') || PackageManager.hasYarnLockFile()) {
             return 'yarn';
         }
 
         return 'npm';
+    }
+
+    static hasYarnLockFile() {
+        const paths = new Paths();
+
+        return File.exists(paths.root('yarn.lock'));
     }
 }
 

--- a/src/PackageManager.js
+++ b/src/PackageManager.js
@@ -2,7 +2,7 @@ class PackageManager {
     static detect() {
         const execPath = process.env.npm_execpath || '';
 
-        if (execPath.endsWith('bin/yarn.js')) {
+        if (execPath.endsWith('yarn.js')) {
             return 'yarn';
         }
 


### PR DESCRIPTION
In Windows:  
```
process.env.npm_execpath = "C:\Program Files (x86)\Yarn\bin\yarn.js"
or
"C:\Program Files\nodejs\node_modules\npm\bin\npm-cli.js"
```

I think just checking the filename is enough. Otherwise the slash of the path is very annoying.