### PR TITLE
Modify config for webpack-dev-server

### DIFF
--- a/src/builder/WebpackConfig.js
+++ b/src/builder/WebpackConfig.js
@@ -98,7 +98,6 @@ class WebpackConfig {
         this.webpackConfig.output = {
             ...this.webpackConfig.output,
 
-            path: '/',
             publicPath: url
         };
 

--- a/src/builder/webpack-default.js
+++ b/src/builder/webpack-default.js
@@ -7,7 +7,7 @@ module.exports = function() {
 
         mode: Mix.inProduction() ? 'production' : 'development',
 
-        infrastructureLogging: Mix.isWatching() ? {} : { level: 'none' },
+        infrastructureLogging: Mix.isWatching() ? { level: 'none' } : {},
 
         entry: {},
 


### PR DESCRIPTION
[output.path](https://webpack.js.org/configuration/output/#outputpath) is the output directory as an absolute path. so `/` is an invalid value.
Also, devServer does not create files on disk by default (see [writeToDisk](https://webpack.js.org/configuration/dev-server/#devserverwritetodisk-)).
With the above issue, `mix watch --hot` currently using `webpack-dev-server` doesn't work.

And fix this by setting [infrastructureLogging](https://webpack.js.org/configuration/other-options/#level) incorrectly on #2660.