### PR TITLE
Support .cjs fallback for mix config file

### DIFF
--- a/src/Paths.js
+++ b/src/Paths.js
@@ -28,11 +28,19 @@ class Paths {
      * Determine the path to the user's webpack.mix.js file.
      */
     mix() {
-        return this.root(
-            process.env && process.env.MIX_FILE
-                ? process.env.MIX_FILE
-                : 'webpack.mix'
+        const path = this.root(
+            process.env && process.env.MIX_FILE ? process.env.MIX_FILE : 'webpack.mix'
         );
+
+        try {
+            require.resolve(`${path}.cjs`);
+
+            return `${path}.cjs`;
+        } catch (err) {
+            //
+        }
+
+        return path;
     }
 
     /**


### PR DESCRIPTION
Closes #2580

This allows mix to work out of the box for anyone using `"type": "module"` in their package.json.

Note: if you're using tailwind you'll have to rename the config file to `tailwind.config.cjs` if you're using `require("tailwind")` in your mix file.