### PR TITLE
Fix buffer polyfill

### DIFF
--- a/src/components/LegacyNodePolyfills.js
+++ b/src/components/LegacyNodePolyfills.js
@@ -9,7 +9,7 @@ class LegacyNodePolyfills extends AutomaticComponent {
 
         return [
             new webpack.ProvidePlugin({
-                Buffer: 'buffer',
+                Buffer: ['buffer', 'Buffer'],
                 process: 'process/browser'
             })
         ];

--- a/test/fixtures/integration/src/js/node-browser-polyfills.js
+++ b/test/fixtures/integration/src/js/node-browser-polyfills.js
@@ -2,6 +2,7 @@
 const log = message => console.log(`node-polyfill: ${message}`);
 
 log(`Buffer ${typeof Buffer}`);
+log(`Buffer.from ${typeof Buffer !== 'undefined' ? typeof Buffer.from : 'undefined'}`);
 log(`process ${typeof process}`);
 log(`process.env ${typeof process !== 'undefined' ? typeof process.env : 'undefined'}`);
 log(`process.env.NODE_ENV ${typeof process.env.NODE_ENV} = ${process.env.NODE_ENV}`);

--- a/test/integration/mix.js
+++ b/test/integration/mix.js
@@ -64,7 +64,8 @@ test('node browser polyfills: enabled', async t => {
 
     await webpack.compile();
     await assertProducesLogs(t, [
-        'node-polyfill: Buffer object',
+        'node-polyfill: Buffer function',
+        'node-polyfill: Buffer.from function',
         'node-polyfill: process object',
         'node-polyfill: process.env object',
         'node-polyfill: process.env.NODE_ENV string = test'
@@ -80,6 +81,7 @@ test('node browser polyfills: disabled', async t => {
     await webpack.compile();
     await assertProducesLogs(t, [
         'node-polyfill: Buffer undefined',
+        'node-polyfill: Buffer.from undefined',
         'node-polyfill: process undefined',
         'node-polyfill: process.env undefined',
         'node-polyfill: process.env.NODE_ENV string = test'


### PR DESCRIPTION
Buffer is available as a named export not a default export from the `buffer` module. This fixes that.