### PR TITLE
Fix scripts formatting in upgrade guide

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -36,48 +36,24 @@ While you're at it, go ahead and switch over to the new Mix CLI.
 ##### Before
 
 ```js
-"scripts"
-:
-{
-    "development"
-:
-    "cross-env NODE_ENV=development node_modules/webpack/bin/webpack.js --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js",
-        "watch"
-:
-    "npm run development -- --watch",
-        "watch-poll"
-:
-    "npm run watch -- --watch-poll",
-        "hot"
-:
-    "cross-env NODE_ENV=development node_modules/webpack-dev-server/bin/webpack-dev-server.js --inline --hot --disable-host-check --config=node_modules/laravel-mix/setup/webpack.config.js",
-        "production"
-:
-    "cross-env NODE_ENV=production node_modules/webpack/bin/webpack.js --no-progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js"
+"scripts": {
+    "development": "cross-env NODE_ENV=development node_modules/webpack/bin/webpack.js --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js",
+        "watch": "npm run development -- --watch",
+        "watch-poll": "npm run watch -- --watch-poll",
+        "hot": "cross-env NODE_ENV=development node_modules/webpack-dev-server/bin/webpack-dev-server.js --inline --hot --disable-host-check --config=node_modules/laravel-mix/setup/webpack.config.js",
+        "production": "cross-env NODE_ENV=production node_modules/webpack/bin/webpack.js --no-progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js"
 }
 ```
 
 ##### After
 
 ```js
-"scripts"
-:
-{
-    "development"
-:
-    "mix",
-        "watch"
-:
-    "mix watch",
-        "watch-poll"
-:
-    "mix watch -- --watch-options-poll=1000",
-        "hot"
-:
-    "mix watch --hot",
-        "production"
-:
-    "mix --production"
+"scripts": {
+    "development": "mix",
+    "watch": "mix watch",
+    "watch-poll": "mix watch -- --watch-options-poll=1000",
+    "hot": "mix watch --hot",
+    "production": "mix --production"
 }
 ```
 


### PR DESCRIPTION
The format of the scripts section must have been messed up by some auto-formatter or similar. This PR fixes this.