### PR TITLE
[DNM] Log segfaults to stderr

### DIFF
--- a/package.json
+++ b/package.json
@@ -122,6 +122,7 @@
         "sass": "^1.27.0",
         "sass-loader": "^10.0.3",
         "sass-resources-loader": "^2.1.1",
+        "segfault-handler": "^1.3.0",
         "sinon": "^9.2.0",
         "stylus": "^0.54.8",
         "stylus-loader": "^4.1.1",

--- a/test/helpers/mix.js
+++ b/test/helpers/mix.js
@@ -1,7 +1,10 @@
+import SegfaultHandler from 'segfault-handler';
 import test from 'ava';
 import bootstrap from '../../src/bootstrap';
 import Stub from './Stub';
 import fs from 'fs-extra';
+
+SegfaultHandler.registerHandler();
 
 global.Stub = Stub;
 


### PR DESCRIPTION
So the intermittent playwright error is now gone but Node 14 on Windows 10 has seen problems with access violations on Win 10 (see https://github.com/nodejs/help/issues/2660)

They supposedly disappeared but seeing that we're having the same problem that appears to not (or no longer) be the case.

I'm attempting to capture a stack trace here when it crashes to see if we need to file a bug with Node. We'll see if that's actually possible. If it's not I'll close this PR and work on this another day as we've got some other Mix bugs to take care of.