### PR TITLE
Prevent CSS imports in Js from resulting in extra CSS files

### DIFF
--- a/src/Mix.js
+++ b/src/Mix.js
@@ -15,6 +15,18 @@ class Mix {
         this.tasks = [];
         this.bundlingJavaScript = false;
         this.components = new Components();
+
+        /**
+         * @internal
+         * @type {string|null}
+         */
+        this.globalStyles = null;
+
+        /**
+         * @internal
+         * @type {boolean|string}
+         **/
+        this.extractingStyles = false;
     }
 
     /**

--- a/test/features/preprocessors.js
+++ b/test/features/preprocessors.js
@@ -303,3 +303,12 @@ test('CSS url resolution can be disabled for PostCSS: globally (after)', async t
     t.false(File.exists(`test/fixtures/app/dist/images/img.svg`));
     t.false(File.exists(`test/fixtures/app/dist/images/img2.svg`));
 });
+
+test.only('CSS imported in JS does not result in separate files by default', async t => {
+    mix.js('test/fixtures/app/src/js/import-css-module.js', 'js');
+
+    await webpack.compile();
+
+    t.true(File.exists(`test/fixtures/app/dist/js/import-css-module.js`));
+    t.false(File.exists(`test/fixtures/app/dist/js/import-css-module.css`));
+});

--- a/test/fixtures/app/src/css/app.module.css
+++ b/test/fixtures/app/src/css/app.module.css
@@ -1,0 +1,3 @@
+.something {
+    color: blue;
+}

--- a/test/fixtures/app/src/js/import-css-module.js
+++ b/test/fixtures/app/src/js/import-css-module.js
@@ -1,0 +1,2 @@
+import '../css/app.css';
+import '../css/app.module.css';


### PR DESCRIPTION
Fixes #2733

Not related to react at all it seems. :)