### PR TITLE
Fix breaking change in mix.webpackConfig

### DIFF
--- a/src/builder/MergeWebpackConfig.js
+++ b/src/builder/MergeWebpackConfig.js
@@ -1,5 +1,12 @@
 let { mergeSmart } = require('./MergeSmart');
 
+/** @typedef {import('webpack').Configuration} Configuration */
+
+/**
+ *
+ * @param {Configuration} configA
+ * @param {Configuration} configB
+ */
 module.exports = (configA, configB) => {
     return mergeSmart(configA, configB);
 };

--- a/src/components/WebpackConfig.js
+++ b/src/components/WebpackConfig.js
@@ -1,6 +1,13 @@
 let merge = require('../builder/MergeWebpackConfig');
 
+/** @typedef {import('webpack').Configuration} Configuration */
+/** @typedef {import('webpack')} webpack */
+
 class WebpackConfig {
+    /**
+     *
+     * @param {((webpack: webpack, config: Configuration) => Configuration)|Configuration} config
+     */
     register(config) {
         global.Mix.api.override(webpackConfig => {
             config = typeof config == 'function' ? config(webpackConfig) : config;

--- a/src/components/WebpackConfig.js
+++ b/src/components/WebpackConfig.js
@@ -1,4 +1,5 @@
 let merge = require('../builder/MergeWebpackConfig');
+let webpack = require('webpack');
 
 /** @typedef {import('webpack').Configuration} Configuration */
 /** @typedef {import('webpack')} webpack */
@@ -10,7 +11,8 @@ class WebpackConfig {
      */
     register(config) {
         global.Mix.api.override(webpackConfig => {
-            config = typeof config == 'function' ? config(webpackConfig) : config;
+            config =
+                typeof config == 'function' ? config(webpack, webpackConfig) : config;
 
             Object.assign(webpackConfig, merge(webpackConfig, config));
         });

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -57,7 +57,10 @@ declare namespace mix {
 
         /** Merge custom webpack config */
         webpackConfig(
-            callback: (webpack: typeof import('webpack')) => webpack.Configuration
+            callback: (
+                webpack: typeof import('webpack'),
+                config: webpack.Configuration
+            ) => webpack.Configuration
         ): Api;
 
         /** Override the webpack config after it is built */


### PR DESCRIPTION
Seems like people were using the webpack import from the function version. I definitely think we should change this in the next major release though.

Fixes #2750