### PR TITLE
Better unsupported version error message

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -4,6 +4,7 @@ const { Command } = require('commander');
 const { spawn } = require('child_process');
 const path = require('path');
 const pkg = require('../package.json');
+const { assertSupportedNodeVersion } = require('../src/Engine.js');
 
 run().catch(err => {
     console.error(err);
@@ -54,6 +55,8 @@ async function run() {
  * @param {string[]} args
  */
 async function executeScript(cmd, opts, args = []) {
+    assertSupportedNodeVersion();
+
     const env = getEffectiveEnv(opts);
 
     // We MUST use a relative path because the files

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -5,7 +5,12 @@ const { spawn } = require('child_process');
 const path = require('path');
 const pkg = require('../package.json');
 
-run();
+run().catch(err => {
+    console.error(err);
+
+    process.exitCode = process.exitCode || 1;
+    process.exit();
+});
 
 /**
  * Run the program.

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -3,6 +3,7 @@
 const { Command } = require('commander');
 const { spawn } = require('child_process');
 const path = require('path');
+const pkg = require('../package.json');
 
 run();
 
@@ -13,7 +14,7 @@ async function run() {
     const program = new Command();
 
     program.name('mix');
-    program.version('0.0.1');
+    program.version(pkg.version);
     program.option(
         '--mix-config <path>',
         'The path to your Mix configuration file.',

--- a/setup/webpack.config.js
+++ b/setup/webpack.config.js
@@ -1,4 +1,8 @@
+const { assertSupportedNodeVersion } = require('../src/Engine');
+
 module.exports = async () => {
+    assertSupportedNodeVersion();
+
     const mix = require('../src/Mix').primary;
 
     require(mix.paths.mix());

--- a/src/Engine.js
+++ b/src/Engine.js
@@ -1,0 +1,10 @@
+const semver = require('semver');
+const pkg = require('../package.json');
+
+module.exports.assertSupportedNodeVersion = function assertSupportedNodeVersion() {
+    if (!semver.satisfies(process.versions.node, pkg.engines.node)) {
+        throw new Error(
+            `You are using an unspported version of Node. Please update to at least Node v12.14`
+        );
+    }
+};


### PR DESCRIPTION
Right now if you run on Node v10 (which Mix v5 supported) you'll get a parse error because of the use of class static properties. We've had a few issues about this.

I've tweaked the setup here to throw a descriptive error in case you run the Mix CLI or run the webpack config file manually on an unsupported node version (determined automatically by package.json).

Note: I've tested the CLI run manually on Node v9 and the webpack run on Node v10. Any earlier for either situation and you get parse errors related to the files / tools being used.