### PR TITLE
Recover https option in hot command

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -24,6 +24,7 @@ async function run() {
         .command('watch')
         .description('Build and watch files for changes.')
         .option('--hot', 'Enable hot reloading.', false)
+        .option('--https', 'Enable https.', false)
         .action(cmd =>
             executeScript('watch', { ...program.opts(), ...cmd.opts() }, cmd.args)
         );

--- a/src/builder/WebpackConfig.js
+++ b/src/builder/WebpackConfig.js
@@ -93,7 +93,7 @@ class WebpackConfig {
             return;
         }
 
-        const {isHttps, host, port} = Config.hmrOptions;
+        const {https, host, port} = Config.hmrOptions;
         const protocol = https ? 'https' : 'http';
         const url = `${protocol}://${host}:${port}/`;
 

--- a/src/builder/WebpackConfig.js
+++ b/src/builder/WebpackConfig.js
@@ -94,7 +94,7 @@ class WebpackConfig {
         }
 
         const {isHttps, host, port} = Config.hmrOptions;
-        const protocol = isHttps ? 'https' : 'http';
+        const protocol = https ? 'https' : 'http';
         const url = `${protocol}://${host}:${port}/`;
 
         this.webpackConfig.output = {
@@ -115,7 +115,7 @@ class WebpackConfig {
             public: url,
             liveReload: false,
             
-            https: isHttps,
+            https,
 
             dev: {
                 headers: {

--- a/src/builder/WebpackConfig.js
+++ b/src/builder/WebpackConfig.js
@@ -93,16 +93,15 @@ class WebpackConfig {
             return;
         }
 
-        let http = process.argv.includes('--https') ? 'https' : 'http';
-        const url = `${http}://${Config.hmrOptions.host}:${Config.hmrOptions.port}/`;
+        const {isHttps, host, port} = Config.hmrOptions;
+        const protocol = isHttps ? 'https' : 'http';
+        const url = `${protocol}://${host}:${port}/`;
 
         this.webpackConfig.output = {
             ...this.webpackConfig.output,
 
             publicPath: url
         };
-
-        const { host, port } = Config.hmrOptions;
 
         this.webpackConfig.devServer = {
             host,
@@ -115,6 +114,8 @@ class WebpackConfig {
 
             public: url,
             liveReload: false,
+            
+            https: isHttps,
 
             dev: {
                 headers: {

--- a/src/config.js
+++ b/src/config.js
@@ -22,6 +22,7 @@ module.exports = function () {
          * @type {Object}
          */
         hmrOptions: {
+            isHttps: !!argv.https,
             host: 'localhost',
             port: !!argv.hmrPort ? argv.hmrPort : '8080'
         },

--- a/src/config.js
+++ b/src/config.js
@@ -22,7 +22,7 @@ module.exports = function () {
          * @type {Object}
          */
         hmrOptions: {
-            isHttps: !!argv.https,
+            https: !!argv.https,
             host: 'localhost',
             port: !!argv.hmrPort ? argv.hmrPort : '8080'
         },

--- a/types/config.d.ts
+++ b/types/config.d.ts
@@ -26,6 +26,9 @@ interface MixConfig {
         port: string;
     };
 
+    /** Determine if we should enable https on hot reloading. */
+    https?: boolean;
+
     /**
      * PostCSS plugins to be applied to compiled CSS.
      *


### PR DESCRIPTION
```
error: unknown option '--https'
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! working-note@ hot: `mix watch --hot --https`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the working-note@ hot script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
```

I currently have the same problem as above on laravel-mix 6.
Fixes an issue where https is not properly supported when laravel-mix is upgraded to version 6.