### PR TITLE
Add supported node version badge to README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,7 @@
 <p align="center"><img src="https://laravel.com/assets/img/components/logo-mix.svg" alt="Laravel Mix"></p>
 
 <p align="center">
+<a href="https://www.npmjs.com/package/laravel-mix"><img src="https://img.shields.io/node/v/laravel-mix.svg" alt="Node"></a>
 <a href="https://www.npmjs.com/package/laravel-mix"><img src="https://img.shields.io/npm/v/laravel-mix.svg" alt="NPM"></a>
 <a href="https://npmcharts.com/compare/laravel-mix?minimal=true"><img src="https://img.shields.io/npm/dt/laravel-mix.svg" alt="NPM"></a>
 <a href="https://www.npmjs.com/package/laravel-mix"><img src="https://img.shields.io/npm/l/laravel-mix.svg" alt="NPM"></a>


### PR DESCRIPTION
This PR adds the currently supported node versions to the `README.md`.

### The reasoning behind the badge.

I feel this will solve many end-users issues of running `mix` and it not working due to them running unsupported versions of node, since the upgrade from `v5` to `v6` bumps the minimum supported version of node from `v8` to `v12` many end-users are still running versions lesser than `v12`.

This change is also not communicated anywhere as far as I can see, it's not mentioned in the **Upgrade** section of the documentation - Review Your Dependencies only talks about the new `webpack` and `PostCSS` versions, but it doesn't talk about the major version bump taken with the underlying node versions.

To debug this issue end-users will have to know that npm packages can add the required node versions and where that information is stored. This information isn't readily available to end-users who don't know much about node and npm packages.

This badge will hopefully help end-users by giving them clear information about which node versions Laravel Mix 6 supports.