### PR TITLE
Update resolve-url-loader dependency for sass

### DIFF
--- a/src/components/Sass.js
+++ b/src/components/Sass.js
@@ -9,7 +9,7 @@ class Sass extends Preprocessor {
 
         return tap(['sass-loader@8.*', 'sass'], dependencies => {
             if (Config.processCssUrls) {
-                dependencies.push('resolve-url-loader@3.1.0');
+                dependencies.push('resolve-url-loader@^3.1.2');
             }
         });
     }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/9105017/105668656-a2882680-5e92-11eb-8fbe-b97f39c4dcf9.png)

Fix audit of resolve-url-loader among Sass component dependencies

## Reference
https://www.npmjs.com/advisories/1573