### PR TITLE
Add --no-progress option to CLI

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -19,6 +19,7 @@ async function run() {
         'The path to your Mix configuration file.',
         'webpack.mix'
     );
+    program.option('--no-progress', 'Disable progress reporting', false);
 
     program
         .command('watch')
@@ -90,7 +91,7 @@ async function executeScript(cmd, opts, args = []) {
  * @param {{[key: string]: any}} opts
  */
 function commandScript(cmd, opts) {
-    const showProgress = isTTY();
+    const showProgress = isTTY() && opts.progress;
 
     if (cmd === 'build') {
         if (showProgress) {

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -90,14 +90,16 @@ async function executeScript(cmd, opts, args = []) {
  * @param {{[key: string]: any}} opts
  */
 function commandScript(cmd, opts) {
+    const showProgress = isTTY();
+
     if (cmd === 'build') {
-        if (isTTY()) {
+        if (showProgress) {
             return 'npx webpack --progress';
         }
 
         return 'npx webpack';
     } else if (cmd === 'watch' && !opts.hot) {
-        if (isTTY()) {
+        if (showProgress) {
             return 'npx webpack --progress --watch';
         }
 

--- a/test/unit/cli.js
+++ b/test/unit/cli.js
@@ -123,3 +123,14 @@ test('it disables progress reporting when not using a terminal', async t => {
         stdout
     );
 });
+
+test('it disables progress reporting when requested', async t => {
+    let { stdout } = await mix(['--no-progress']);
+
+    t.is(
+        'cross-env NODE_ENV=development MIX_FILE="webpack.mix" npx webpack --config="' +
+            configPath +
+            '"',
+        stdout
+    );
+});

--- a/test/unit/cli.js
+++ b/test/unit/cli.js
@@ -116,6 +116,8 @@ test('it disables progress reporting when not using a terminal', async t => {
 
     let { stdout } = await mix();
 
+    delete process.env.IS_TTY;
+
     t.is(
         'cross-env NODE_ENV=development MIX_FILE="webpack.mix" npx webpack --config="' +
             configPath +


### PR DESCRIPTION
Adds a `--no-progress` option to the CLI to disable progress reporting.

ping @JosephSilber