### PR TITLE
Fix  react-refresh in React Component

### DIFF
--- a/src/Dependencies.js
+++ b/src/Dependencies.js
@@ -145,7 +145,7 @@ class Dependencies {
         }
 
         function isValid() {
-            return dep.check ? dep.check(require(name)) : true;
+            return dep.check ? dep.check(name) : true;
         }
 
         return {

--- a/src/components/CssWebpackConfig.js
+++ b/src/components/CssWebpackConfig.js
@@ -11,7 +11,8 @@ class CssWebpackConfig extends AutomaticComponent {
         return [
             {
                 package: 'postcss@^8.1',
-                check: postcss => semver.satisfies(postcss().version, '^8.1')
+                check: name =>
+                    semver.satisfies(require(`${name}/package.json`).version, '^8.1')
             }
         ];
     }

--- a/src/components/React.js
+++ b/src/components/React.js
@@ -40,7 +40,11 @@ class React {
 
         const ReactRefreshWebpackPlugin = require('@pmmmwh/react-refresh-webpack-plugin');
 
-        return new ReactRefreshWebpackPlugin({ overlay: false });
+        return new ReactRefreshWebpackPlugin({
+            overlay: {
+                sockPath: 'ws'
+            }
+        });
     }
 
     /**

--- a/src/components/React.js
+++ b/src/components/React.js
@@ -11,8 +11,11 @@ class React {
             return dependencies.concat([
                 {
                     package: '@pmmmwh/react-refresh-webpack-plugin@^0.5.0-beta.0',
-                    check: dependency =>
-                        semver.satisfies(dependency.version, '^0.5.0-beta.0')
+                    check: name =>
+                        semver.satisfies(
+                            require(`${name}/package.json`).version,
+                            '^0.5.0-beta.0'
+                        )
                 },
                 'react-refresh'
             ]);

--- a/src/components/React.js
+++ b/src/components/React.js
@@ -1,3 +1,5 @@
+const semver = require('semver');
+
 class React {
     /**
      * Required dependencies for the component.
@@ -7,7 +9,11 @@ class React {
 
         if (this.supportsFastRefreshing()) {
             return dependencies.concat([
-                '@pmmmwh/react-refresh-webpack-plugin',
+                {
+                    package: '@pmmmwh/react-refresh-webpack-plugin@^0.5.0-beta.0',
+                    check: dependency =>
+                        semver.satisfies(dependency.version, '^0.5.0-beta.0')
+                },
                 'react-refresh'
             ]);
         }
@@ -38,13 +44,9 @@ class React {
             return [];
         }
 
-        const ReactRefreshWebpackPlugin = require('@pmmmwh/react-refresh-webpack-plugin');
+        const ReactRefreshPlugin = require('@pmmmwh/react-refresh-webpack-plugin');
 
-        return new ReactRefreshWebpackPlugin({
-            overlay: {
-                sockPath: 'ws'
-            }
-        });
+        return new ReactRefreshPlugin({ overlay: { sockPath: 'ws' } });
     }
 
     /**
@@ -65,13 +67,7 @@ class React {
      * Determine if the React version supports fast refreshing.
      */
     supportsFastRefreshing() {
-        try {
-            const semver = require('semver');
-
-            return Mix.isHot() && semver.satisfies(this.library().version, '>=16.9.0');
-        } catch {
-            return false;
-        }
+        return Mix.isHot() && semver.satisfies(this.library().version, '>=16.9.0');
     }
 
     /**

--- a/src/components/React.js
+++ b/src/components/React.js
@@ -40,7 +40,7 @@ class React {
 
         const ReactRefreshWebpackPlugin = require('@pmmmwh/react-refresh-webpack-plugin');
 
-        return new ReactRefreshWebpackPlugin();
+        return new ReactRefreshWebpackPlugin({ overlay: false });
     }
 
     /**

--- a/test/features/react.js
+++ b/test/features/react.js
@@ -93,7 +93,13 @@ test('it adds the necessary fast refreshing dependencies', t => {
 
     let dependencies = react.dependencies();
 
-    t.true(dependencies.includes('@pmmmwh/react-refresh-webpack-plugin'));
+    t.truthy(
+        dependencies.find(
+            dependency =>
+                dependency.package ===
+                '@pmmmwh/react-refresh-webpack-plugin@^0.5.0-beta.0'
+        )
+    );
     t.true(dependencies.includes('react-refresh'));
 });
 

--- a/test/unit/Dependencies.js
+++ b/test/unit/Dependencies.js
@@ -84,10 +84,10 @@ test('it can utilize custom checks for a dependency', t => {
     new Dependencies([
         {
             package: 'postcss@^8.1',
-            check: postcss => {
+            check: name => {
                 called = true;
 
-                t.true(semver.satisfies(postcss().version, '^8.1'));
+                t.true(semver.satisfies(require(`${name}/package.json`).version, '^8.1'));
 
                 return false;
             }


### PR DESCRIPTION
This is because when you enable overlay, you get websocket related errors.

I hope to re-enable after resolving this.

![image](https://user-images.githubusercontent.com/9105017/106039749-57d2fe00-608e-11eb-82ae-3d3df9bbbc1b.png)

## Update
`@pmmmwh/react-refresh-webpack-plugin` was updated to the `^0.5.0-beta.0` version that supports `webpack-dev-server` `4.0.0-beta.0`, and solve the phenomenon that `hmr` does not work normally when using react components