### PR TITLE
Update sass-loader

### DIFF
--- a/src/components/Sass.js
+++ b/src/components/Sass.js
@@ -7,7 +7,7 @@ class Sass extends Preprocessor {
     dependencies() {
         this.requiresReload = true;
 
-        return tap(['sass-loader@8.*', 'sass'], dependencies => {
+        return tap(['sass-loader@10.*', 'sass'], dependencies => {
             if (Config.processCssUrls) {
                 dependencies.push('resolve-url-loader@^3.1.2');
             }


### PR DESCRIPTION
When sass-loader is missing in local package.json tap is installing an older version. 