### PR TITLE
Set exit status 126 if warnings like "Please run Mix again." happens

### DIFF
--- a/src/Dependencies.js
+++ b/src/Dependencies.js
@@ -118,7 +118,7 @@ class Dependencies {
             );
 
             if (process.env.NODE_ENV !== 'test') {
-                process.exit();
+                process.exit(126);
             }
         }
     }

--- a/src/Dependencies.js
+++ b/src/Dependencies.js
@@ -118,7 +118,7 @@ class Dependencies {
             );
 
             if (process.env.NODE_ENV !== 'test') {
-                process.exit(126);
+                process.exit(1);
             }
         }
     }


### PR DESCRIPTION
Sometimes Laravel mix requires additional dependencies, which installs automatically with console message: "Please run Mix again."
The problem is that it exists with a default exit code=0, so it looks like command `npm run production` completed successfully and can be deployed to production (so it was already happened).
The PR set exit code to 126 "Command invoked cannot execute" and it can be catched by a CI correctly as fail. 