### PR TITLE
Remove need for cross-env

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
 
+// @ts-check
+
 const { Command } = require('commander');
 const { spawn } = require('child_process');
 const path = require('path');
@@ -79,7 +81,9 @@ async function executeScript(cmd, opts, args = []) {
     };
 
     if (isTesting()) {
-        return process.stdout.write(script);
+        process.stdout.write(script);
+
+        return;
     }
 
     function restart() {

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -81,7 +81,12 @@ async function executeScript(cmd, opts, args = []) {
     };
 
     if (isTesting()) {
-        process.stdout.write(script);
+        process.stdout.write(
+            JSON.stringify({
+                script,
+                env: scriptEnv
+            })
+        );
 
         return;
     }

--- a/package.json
+++ b/package.json
@@ -68,7 +68,6 @@
         "collect.js": "^4.28.4",
         "commander": "^6.1.0",
         "concat": "^1.0.3",
-        "cross-env": "^7.0.2",
         "css-loader": "^5.0.0",
         "cssnano": "^4.1.10",
         "dotenv": "^8.2.0",

--- a/test/helpers/cli.js
+++ b/test/helpers/cli.js
@@ -5,6 +5,14 @@ import { promisify } from 'util';
 const execAsync = promisify(exec);
 
 /**
+ * @typedef {object} CliResult
+ * @property {Error|null} error
+ * @property {number} code
+ * @property {string} stdout
+ * @property {string} stderr
+ */
+
+/**
  * Return a helper function appropriately configured to run the Mix CLI
  *
  * @param {{testing?: boolean, cwd?: string, env?: Record<string, string>}} opts
@@ -21,18 +29,20 @@ export function cli(opts) {
      * Run the Mix CLI
      *
      * @param {string[]} args
+     * @returns {Promise<CliResult>}
      */
-    return async function (args = []) {
-        let cmd = [
-            `cross-env`,
-            ...Object.entries(env).map(env => `${env[0]}=${env[1]}`),
-            testing ? 'TESTING=1' : '',
-            `node ${path.resolve('./bin/cli')}`,
-            ...args
-        ];
+    async function run(args = []) {
+        let cmd = [`node ${path.resolve('./bin/cli')}`, ...args];
 
         try {
-            const { stdout, stderr } = await execAsync(cmd.join(' '), { cwd });
+            const { stdout, stderr } = await execAsync(cmd.join(' '), {
+                cwd,
+                env: {
+                    ...process.env,
+                    ...env,
+                    TESTING: testing ? '1' : undefined
+                }
+            });
 
             return {
                 error: null,
@@ -50,5 +60,20 @@ export function cli(opts) {
                 stderr
             };
         }
-    };
+    }
+
+    /**
+     * Run the Mix and build in assertions
+     *
+     * @param {string[]} args
+     */
+    async function testRun(args = []) {
+        const result = await run(args);
+
+        return {
+            ...result
+        };
+    }
+
+    return testRun;
 }

--- a/test/helpers/cli.js
+++ b/test/helpers/cli.js
@@ -69,9 +69,26 @@ export function cli(opts) {
      */
     async function testRun(args = []) {
         const result = await run(args);
+        const stdout = testing ? JSON.parse(result.stdout) : { script: null, env: {} };
 
         return {
-            ...result
+            ...result,
+
+            /**
+             * @param {import("ava").Assertions} t
+             * @param {string} script
+             **/
+            assertScript(t, script) {
+                t.is(stdout.script, script);
+            },
+
+            /**
+             * @param {import("ava").Assertions} t
+             * @param {Record<string, string>} env
+             **/
+            assertEnv(t, env) {
+                t.deepEqual(stdout.env, env);
+            }
         };
     }
 

--- a/test/unit/cli.js
+++ b/test/unit/cli.js
@@ -15,83 +15,61 @@ test.before(() => {
 });
 
 test('it calls webpack in development mode', async t => {
-    let { stdout } = await mix();
+    const result = await mix();
 
-    t.is(
-        'cross-env NODE_ENV=development MIX_FILE="webpack.mix" npx webpack --progress --config="' +
-            configPath +
-            '"',
-        stdout
-    );
+    result.assertScript(t, `npx webpack --progress --config="${configPath}"`);
+    result.assertEnv(t, { MIX_FILE: 'webpack.mix', NODE_ENV: 'development' });
 });
 
 test('it calls webpack in production mode', async t => {
-    let { stdout } = await mix(['--production']);
+    const result = await mix(['--production']);
 
-    t.is(
-        'cross-env NODE_ENV=production MIX_FILE="webpack.mix" npx webpack --progress --config="' +
-            configPath +
-            '"',
-        stdout
-    );
+    result.assertScript(t, `npx webpack --progress --config="${configPath}"`);
+    result.assertEnv(t, { MIX_FILE: 'webpack.mix', NODE_ENV: 'production' });
 });
 
 test('it calls webpack with watch mode', async t => {
-    let { stdout } = await mix(['watch']);
+    const result = await mix(['watch']);
 
-    t.is(
-        'cross-env NODE_ENV=development MIX_FILE="webpack.mix" npx webpack --progress --watch --config="' +
-            configPath +
-            '"',
-        stdout
-    );
+    result.assertScript(t, `npx webpack --progress --watch --config="${configPath}"`);
+    result.assertEnv(t, { MIX_FILE: 'webpack.mix', NODE_ENV: 'development' });
 });
 
 test('it calls webpack with watch mode using polling', async t => {
-    let { stdout } = await mix(['watch', '--', '--watch-poll']);
+    const result = await mix(['watch', '--', '--watch-poll']);
 
-    t.is(
-        'cross-env NODE_ENV=development MIX_FILE="webpack.mix" npx webpack --progress --watch --config="' +
-            configPath +
-            '"' +
-            ' --watch-poll',
-        stdout
+    result.assertScript(
+        t,
+        `npx webpack --progress --watch --config="${configPath}" --watch-poll`
     );
+    result.assertEnv(t, { MIX_FILE: 'webpack.mix', NODE_ENV: 'development' });
 });
 
 test('it calls webpack with hot reloading', async t => {
-    let { stdout } = await mix(['watch', '--hot']);
+    const result = await mix(['watch', '--hot']);
 
-    t.is(
-        'cross-env NODE_ENV=development MIX_FILE="webpack.mix" npx webpack serve --hot --config="' +
-            configPath +
-            '"',
-        stdout
-    );
+    result.assertScript(t, `npx webpack serve --hot --config="${configPath}"`);
+    result.assertEnv(t, { MIX_FILE: 'webpack.mix', NODE_ENV: 'development' });
 });
 
 test('it calls webpack with hot reloading using polling', async t => {
-    let { stdout } = await mix(['watch', '--hot', '--', '--watch-poll']);
+    const result = await mix(['watch', '--hot', '--', '--watch-poll']);
 
-    t.is(
-        'cross-env NODE_ENV=development MIX_FILE="webpack.mix" npx webpack serve --hot --config="' +
-            configPath +
-            '"' +
-            ' --watch-poll',
-        stdout
+    result.assertScript(
+        t,
+        `npx webpack serve --hot --config="${configPath}" --watch-poll`
     );
+    result.assertEnv(t, { MIX_FILE: 'webpack.mix', NODE_ENV: 'development' });
 });
 
 test('it calls webpack with quoted key value pair command arguments', async t => {
-    let { stdout } = await mix(['--', '--env', 'foo="bar baz"', 'foo="bar=baz"']);
+    const result = await mix(['--', '--env', 'foo="bar baz"', 'foo="bar=baz"']);
 
-    t.is(
-        'cross-env NODE_ENV=development MIX_FILE="webpack.mix" npx webpack --progress --config="' +
-            configPath +
-            '"' +
-            ' --env foo="bar baz" foo="bar=baz"',
-        stdout
+    result.assertScript(
+        t,
+        `npx webpack --progress --config="${configPath}" --env foo="bar baz" foo="bar=baz"`
     );
+    result.assertEnv(t, { MIX_FILE: 'webpack.mix', NODE_ENV: 'development' });
 });
 
 test('it calls webpack with custom node_env', async t => {
@@ -99,40 +77,28 @@ test('it calls webpack with custom node_env', async t => {
 
     process.env.NODE_ENV = 'foobar';
 
-    let { stdout } = await mix();
+    const result = await mix();
 
     process.env.NODE_ENV = oldEnv;
 
-    t.is(
-        'cross-env NODE_ENV=foobar MIX_FILE="webpack.mix" npx webpack --progress --config="' +
-            configPath +
-            '"',
-        stdout
-    );
+    result.assertScript(t, `npx webpack --progress --config="${configPath}"`);
+    result.assertEnv(t, { MIX_FILE: 'webpack.mix', NODE_ENV: 'foobar' });
 });
 
 test('it disables progress reporting when not using a terminal', async t => {
-    process.env.IS_TTY = false;
+    process.env.IS_TTY = '0';
 
-    let { stdout } = await mix();
+    const result = await mix();
 
     delete process.env.IS_TTY;
 
-    t.is(
-        'cross-env NODE_ENV=development MIX_FILE="webpack.mix" npx webpack --config="' +
-            configPath +
-            '"',
-        stdout
-    );
+    result.assertScript(t, `npx webpack --config="${configPath}"`);
+    result.assertEnv(t, { MIX_FILE: 'webpack.mix', NODE_ENV: 'development' });
 });
 
 test('it disables progress reporting when requested', async t => {
-    let { stdout } = await mix(['--no-progress']);
+    const result = await mix(['--no-progress']);
 
-    t.is(
-        'cross-env NODE_ENV=development MIX_FILE="webpack.mix" npx webpack --config="' +
-            configPath +
-            '"',
-        stdout
-    );
+    result.assertScript(t, `npx webpack --config="${configPath}"`);
+    result.assertEnv(t, { MIX_FILE: 'webpack.mix', NODE_ENV: 'development' });
 });


### PR DESCRIPTION
I had a bit of an epiphany when working on some other things which revealed _why_ cross-env was being used and how it's no longer necessary since we spawn processes ourselves now. We pass env vars directly via spawn and exec (which is what cross-env did).

~Also opening to see if the integration tests fail — they started failing on my machine and I haven't figured out why yet.~