### PR TITLE
Disable overlay on react-refresh

### DIFF
--- a/src/builder/webpack-rules.js
+++ b/src/builder/webpack-rules.js
@@ -8,45 +8,49 @@ module.exports = function () {
         use: [{ loader: 'html-loader' }]
     });
 
-    // Add support for loading images.
-    rules.push({
-        // only include svg that doesn't have font in the path or file name by using negative lookahead
-        test: /(\.(png|jpe?g|gif|webp)$|^((?!font).)*\.svg$)/,
-        use: [
-            {
-                loader: 'file-loader',
-                options: {
-                    name: path => {
-                        if (!/node_modules|bower_components/.test(path)) {
-                            return Config.fileLoaderDirs.images + '/[name].[ext]?[hash]';
-                        }
+    if (Config.imgLoaderOptions) {
+        // Add support for loading images.
+        rules.push({
+            // only include svg that doesn't have font in the path or file name by using negative lookahead
+            test: /(\.(png|jpe?g|gif|webp)$|^((?!font).)$)/,
+            use: [
+                {
+                    loader: 'file-loader',
+                    options: {
+                        name: path => {
+                            if (!/node_modules|bower_components/.test(path)) {
+                                return (
+                                    Config.fileLoaderDirs.images + '/[name].[ext]?[hash]'
+                                );
+                            }
 
-                        return (
-                            Config.fileLoaderDirs.images +
-                            '/vendor/' +
-                            path
-                                .replace(/\\/g, '/')
-                                .replace(
-                                    /((.*(node_modules|bower_components))|images|image|img|assets)\//g,
-                                    ''
-                                ) +
-                            '?[hash]'
-                        );
-                    },
-                    publicPath: Config.resourceRoot
+                            return (
+                                Config.fileLoaderDirs.images +
+                                '/vendor/' +
+                                path
+                                    .replace(/\\/g, '/')
+                                    .replace(
+                                        /((.*(node_modules|bower_components))|images|image|img|assets)\//g,
+                                        ''
+                                    ) +
+                                '?[hash]'
+                            );
+                        },
+                        publicPath: Config.resourceRoot
+                    }
+                },
+
+                {
+                    loader: 'img-loader',
+                    options: Config.imgLoaderOptions
                 }
-            },
-
-            {
-                loader: 'img-loader',
-                options: Config.imgLoaderOptions
-            }
-        ]
-    });
+            ]
+        });
+    }
 
     // Add support for loading fonts.
     rules.push({
-        test: /(\.(woff2?|ttf|eot|otf)$|font.*\.svg$)/,
+        test: /(\.(woff2?|ttf|eot|otf)$|font.$)/,
         use: [
             {
                 loader: 'file-loader',

--- a/src/config.js
+++ b/src/config.js
@@ -87,7 +87,7 @@ module.exports = function () {
          * Image Loader defaults.
          * See: https://github.com/thetalecrafter/img-loader#options
          *
-         * @type {Object}
+         * @type {Boolean|Object}
          */
         imgLoaderOptions: {
             enabled: true,


### PR DESCRIPTION
[Svgr](https://react-svgr.com/docs/webpack/) doesn't work because `file-loader` works for the current image. This PR makes it possible to disable the rules for the image for the above situation.

## Aside
other rules that I add by default look similar. I don't think it's an option for everyone. I think I should be able to choose whether to use those rules.