### PR TITLE
Allows relative output paths to be used for sass calls

### DIFF
--- a/src/components/Preprocessor.js
+++ b/src/components/Preprocessor.js
@@ -224,8 +224,9 @@ class Preprocessor {
             enforce: true,
             type: 'css/mini-extract'
         };
+        const path = File.stripPublicDir(output.relativePathWithoutExtension());
 
-        this.chunks.add(name, output.normalizedOutputPath(), tests, attrs);
+        this.chunks.add(name, path, tests, attrs);
     }
 }
 

--- a/test/integration/mix.js
+++ b/test/integration/mix.js
@@ -5,6 +5,7 @@ import { chromium } from 'playwright';
 import webpack, { setupVueAliases } from '../helpers/webpack';
 
 import '../helpers/mix';
+import assert from '../helpers/assertions';
 
 /** @type {import("playwright").Browser} */
 let browser;
@@ -38,6 +39,45 @@ test('compiling just js', async t => {
 
     await webpack.compile();
     await assertProducesLogs(t, ['loaded: app.js']);
+});
+
+test('compiling css into relative directory', async t => {
+    setupVueAliases(3);
+
+    // Build a simple mix setup
+    mix.sass(
+        'test/fixtures/integration/src/css/app.scss',
+        '../../../integration/fixture/public/css/app.css'
+    );
+
+    await webpack.compile();
+    assert.fileExists(`test/integration/fixture/public/css/app.css`, t);
+    await assertProducesLogs(t, [
+        'loaded: app.js',
+        'run: app.js',
+        'loaded: dynamic.js',
+        'run: dynamic.js',
+        'style: rgb(255, 119, 0)',
+        'style: rgb(119, 204, 51)'
+    ]);
+});
+
+test('compiling css using public directory in destination', async t => {
+    setupVueAliases(3);
+
+    // Build a simple mix setup
+    mix.sass('test/fixtures/integration/src/css/app.scss', 'dist/css/app.css');
+
+    await webpack.compile();
+    assert.fileExists(`test/fixtures/integration/dist/css/app.css`, t);
+    await assertProducesLogs(t, [
+        'loaded: app.js',
+        'run: app.js',
+        'loaded: dynamic.js',
+        'run: dynamic.js',
+        'style: rgb(255, 119, 0)',
+        'style: rgb(119, 204, 51)'
+    ]);
 });
 
 test('compiling js and css together', async t => {


### PR DESCRIPTION
May fix #2757 

I am not sure if this is even the correct way to do it but it works and all of the tests pass.