### PR TITLE
HMR - makes laravel-mix do the right thing with a complex hot host

### DIFF
--- a/src/HotReloading.js
+++ b/src/HotReloading.js
@@ -1,5 +1,6 @@
 let path = require('path');
 let File = require('./File');
+let argv = require('yargs').argv;
 
 module.exports = {
     record() {
@@ -10,7 +11,7 @@ module.exports = {
         }
 
         this.hotFile().write(
-            `${this.http()}://${Config.hmrOptions.host}:${this.port()}/`
+            `${this.http()}://${this.host()}:${this.port()}/`
         );
     },
 
@@ -23,9 +24,11 @@ module.exports = {
     },
 
     port() {
-        return process.argv.includes('--port')
-            ? process.argv[process.argv.indexOf('--port') + 1]
-            : Config.hmrOptions.port;
+        return argv.port || Config.hmrOptions.port;
+    },
+
+    host() {
+	return argv.public || argv.host || Config.hmrOptions.host;
     },
 
     clean() {


### PR DESCRIPTION
makes laravel-mix do the right thing with a complex hot host setup such as

npx mix watch --hot -- --https --host=0.0.0.0 --port=8888 --public=myip.net

(I am developing on an AWS server with a load balancer frontend. The above command works, but laravel mix puts the wrong thing in public/hot. This makes it do the right thing and simplifies the code.)