### PR TITLE
Update HMR Options to provide an https configuration property

### DIFF
--- a/src/HotReloading.js
+++ b/src/HotReloading.js
@@ -19,7 +19,7 @@ module.exports = {
     },
 
     http() {
-        return process.argv.includes('--https') ? 'https' : 'http';
+        return process.argv.includes('--https') ? 'https' : (Config.hmrOptions.https === true ? 'https' : 'http');
     },
 
     port() {


### PR DESCRIPTION
CLI support for https/key/cert may return to webpack-dev-server 4, but as of now, it does not seem to support it. Current way to setup dev server to use https is by passing devServer.https as true. Example usage below.

```js
mix.options({
    hmrOptions: {
        https: true,
    },
});

mix.webpackConfig({
    devServer: {
        https: true,
    }
});
```

If someone is using docker and is serving traffic over https (reason I am is because of third party API restrictions), then this is my full usage. The domain variable can be set by parsing out APP_URL.

```js
mix.options({
    hmrOptions: {
        https: true,
        host: domain,
        port: 8080,
    },
});

mix.webpackConfig({
    devServer: {
        https: true,
        host: '0.0.0.0',
        port: 8080,
    },
    watchOptions: {
        aggregateTimeout: 200,
        poll: 1000
    }
});
```