### PR TITLE
CLI watch: fix --hot --https not using https

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -142,7 +142,7 @@ function commandScript(cmd, opts) {
 
         return 'npx webpack --watch';
     } else if (cmd === 'watch' && opts.hot) {
-        return 'npx webpack serve --hot';
+        return 'npx webpack serve --hot' + (opts.https ? ' --https' : '');
     }
 }
 


### PR DESCRIPTION
Despite https://github.com/JeffreyWay/laravel-mix/pull/2783, running `mix --hot --https` does not work. Without this fix:

```
$ mix watch --hot --https

   Laravel Mix v6.0.13   
                         

✔ Compiled Successfully....

...another terminal
$ curl -k https://localhost:8080/
curl: (35) schannel: next InitializeSecurityContext failed: SEC_E_INVALID_TOKEN (0x80090308) - The token supplied to the function is invalid
```

In a browser, it shows `SSL_PROTOCOL_ERROR` with the issue being [SSL_R_WRONG_VERSION_NUMBER](https://github.com/google/boringssl/blob/e7b56750157ad9fcf40e58c22acc436bc4e9a9b9/ssl/tls_record.cc#L232-L245), aka the SSL version was wrong (since it couldn't actually establish a connection) - aka the HTTPS part is not running.

It works without this fix if you pass the flag like so:

```
mix watch --hot -- --https
```
however, given that `https` is supposed to be a first-party option alongside `hot`, I thought this fix was necessary.

https://github.com/JeffreyWay/laravel-mix/blob/f0ef8ab2370cb58fe656c9f285f8cb3144e38f40/bin/cli.js#L36-L37

After the fix:

```
$ mix watch --hot --https

   Laravel Mix v6.0.13   
                         

✔ Compiled Successfully....

$ curl -k https://localhost:8080/
<
<pre>Cannot GET /</pre>
```
 (Normal response since webpack doesn't serve a root-level resource).