### PR TITLE
Bump browser-sync-webpack-plugin version

### DIFF
--- a/src/components/BrowserSync.js
+++ b/src/components/BrowserSync.js
@@ -5,7 +5,7 @@ class BrowserSync {
     dependencies() {
         this.requiresReload = true;
 
-        return ['browser-sync', 'browser-sync-webpack-plugin@2.3.0'];
+        return ['browser-sync', 'browser-sync-webpack-plugin@^2.3.0'];
     }
 
     /**

--- a/src/components/BrowserSync.js
+++ b/src/components/BrowserSync.js
@@ -5,7 +5,7 @@ class BrowserSync {
     dependencies() {
         this.requiresReload = true;
 
-        return ['browser-sync', 'browser-sync-webpack-plugin@2.2.2'];
+        return ['browser-sync', 'browser-sync-webpack-plugin@2.3.0'];
     }
 
     /**


### PR DESCRIPTION
v2.3.0 supports Webpack 5. Probably fixes #2861 as well.