### PR TITLE
Adjust commandScript function to use --https option

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -142,6 +142,9 @@ function commandScript(cmd, opts) {
 
         return 'npx webpack --watch';
     } else if (cmd === 'watch' && opts.hot) {
+        if (opts.https) {
+            return 'npx webpack serve --hot --https';
+        }
         return 'npx webpack serve --hot';
     }
 }


### PR DESCRIPTION
If you type

```shell
npx mix watch -h
```

There is an https option documented as available. However, running the commandScript function throws the https option away.

With the work released in v6.0.13, hmrOptions supports an https flag while the hot file generation still relies on --https being present as a command line argument. To take advantage of the changes in v6.0.13, and get a correct hot file, one would have to type

```shell
npx webpack serve --hot --config="node_modules/laravel-mix/setup/webpack.config.js" --https
```

This patch adjusts the commandScript function to keep --https as a command line argument, which is what the hot file depends upon.