### PR TITLE
Fix mix.when()

### DIFF
--- a/src/components/When.js
+++ b/src/components/When.js
@@ -1,10 +1,8 @@
 class When {
     register(condition, callback) {
         if (condition) {
-            callback(this);
+            callback(Mix.api);
         }
-
-        return this;
     }
 }
 

--- a/test/features/when.js
+++ b/test/features/when.js
@@ -2,7 +2,7 @@ import test from 'ava';
 
 import '../helpers/mix';
 
-test('mix.when()', t => {
+test('it executes the callback based on the condition', t => {
     let called = false;
 
     mix.when(false, () => (called = true));
@@ -12,4 +12,15 @@ test('mix.when()', t => {
     mix.when(true, () => (called = true));
 
     t.true(called);
+});
+
+test('it passes the mix instance to the callback', t => {
+    mix.when(true, _mix => t.deepEqual(mix, _mix));
+});
+
+test('it returns the mix instance', t => {
+    t.deepEqual(
+        mix,
+        mix.when(true, () => {})
+    );
 });

--- a/test/features/when.js
+++ b/test/features/when.js
@@ -17,10 +17,3 @@ test('it executes the callback based on the condition', t => {
 test('it passes the mix instance to the callback', t => {
     mix.when(true, _mix => t.deepEqual(mix, _mix));
 });
-
-test('it returns the mix instance', t => {
-    t.deepEqual(
-        mix,
-        mix.when(true, () => {})
-    );
-});

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -46,8 +46,8 @@ declare namespace mix {
         /** Run a callback after the build has completed */
         then(callback: (stats: webpack.Stats) => void | Promise<void>): Api;
 
-        /** Run a callback after the build has completed */
-        when(callback: () => void | Promise<void>): Api;
+        /** Run a callback if a condition is true */
+        when(condition: boolean, callback: (mix: Api) => void | Promise<void>): Api;
     }
 
     // Webpack config related abilities


### PR DESCRIPTION
I just upgraded an app to mix 6.x and was getting errors for the following section of my `webpack.mix.js`:
```js
    .when(!mix.inProduction(), mix =>
        mix.copy('node_modules/vue/dist/vue.js', 'public/js')
    )
```
There error was `[webpack-cli] TypeError: mix.copy is not a function`, so it seems that the mix instance isn't being passed to the callback. Since [`mix.when()` is my baby](https://github.com/JeffreyWay/laravel-mix/pull/2330), I felt compelled to give it some love.

I haven't been following the development of mix 6 closely, but the move to the new component class system (in 5ad964f) appears to have broken `when()` b/c it changed what `this` refers to. Changing `this` to `Mix.api` appears to fix it, but I'm 100% open to corrections if this isn't the correct way to solve this.

While tinkering, I also realized that the return is no longer needed. I have added tests to verify these changes and I improved the name of the existing test for `mix.when()`.

Hope this helps! Thanks again. BTW the upgrade to v6 was silky smooth (aside from this hiccup).
