### PR TITLE
Update HotReloading.js

### DIFF
--- a/src/HotReloading.js
+++ b/src/HotReloading.js
@@ -10,7 +10,7 @@ module.exports = {
         }
 
         this.hotFile().write(
-            `${this.http()}://${Config.hmrOptions.host}:${this.port()}/`
+            `${this.http()}://${Config.hmrOptions.host}:${this.port()}`
         );
     },
 


### PR DESCRIPTION
Leading slash produces the following hot http://localhost:8080/ that leads to a double slash like so in the link of dev server assets `http://localhost:8080//js/app.js`