### PR TITLE
Add warning for moved vue options

### DIFF
--- a/src/Log.js
+++ b/src/Log.js
@@ -1,3 +1,7 @@
+/**
+ * @typedef {'default' | 'green' | 'red'} LogColor
+ **/
+
 class Log {
     /**
      * Determine if we are in test mode.
@@ -7,17 +11,16 @@ class Log {
     /**
      * All logged messages.
      *
-     * @var {Array}
+     * @type {string[]}
      */
     static fakedLogs = [];
 
     /**
      * Log basic info to the console.
      *
-     * @param  {String} message
-     * @param  {String} color
+     * @param  {string} message
+     * @param  {LogColor} color
      */
-
     static info(message, color = 'default') {
         if (Log.testing) {
             Log.fakedLogs.push(message);
@@ -33,8 +36,8 @@ class Log {
     /**
      * Log feedback info to the console.
      *
-     * @param  {String} message
-     * @param  {String} color
+     * @param  {string} message
+     * @param  {LogColor} color
      */
     static feedback(message, color = 'green') {
         Log.line('\t' + message, color);
@@ -43,8 +46,8 @@ class Log {
     /**
      * Log error info to the console.
      *
-     * @param  {String} message
-     * @param  {String} color
+     * @param  {string} message
+     * @param  {LogColor} color
      */
     static error(message, color = 'red') {
         Log.line(message, color);
@@ -53,8 +56,8 @@ class Log {
     /**
      * Log a new line of info to the console.
      *
-     * @param  {String} message
-     * @param  {String} color
+     * @param  {string} message
+     * @param  {LogColor} color
      */
     static line(message, color = 'default') {
         Log.info(message, color);
@@ -62,9 +65,6 @@ class Log {
 
     /**
      * Reset the default color for future console.logs.
-     *
-     * @param  {String} message
-     * @param  {String} color
      */
     static reset() {
         console.log(Log.colors()['default'], '');
@@ -88,7 +88,7 @@ class Log {
     /**
      * Determine if the given message was logged.
      *
-     * @param  {String} message
+     * @param  {string} message
      */
     static received(message) {
         let result = Log.fakedLogs.some(log => log.includes(message));

--- a/src/Log.js
+++ b/src/Log.js
@@ -1,3 +1,11 @@
+const chalk = require('chalk');
+
+/**
+ * @typedef {object} LogMessage
+ * @property {string} text
+ * @property {'info' | 'warn' | 'error'} type
+ **/
+
 /**
  * @typedef {'default' | 'green' | 'red'} LogColor
  **/
@@ -31,6 +39,39 @@ class Log {
         console.log(Log.colors()[color], message);
 
         Log.reset();
+    }
+
+    /**
+     *
+     * @param {LogMessage} message
+     */
+    static message(message) {
+        if (Log.testing) {
+            Log.fakedLogs.push(message.text);
+
+            return;
+        }
+
+        /** @type {string} */
+        let prefix = '';
+
+        if (message.type === 'info') {
+            prefix = ' INFO ';
+        } else if (message.type === 'warn') {
+            prefix = ' WARN ';
+        } else if (message.type === 'error') {
+            prefix = ' ERR ';
+        }
+
+        const line = message.text.replace(/\n/g, '\n' + ' '.repeat(prefix.length + 1));
+
+        if (message.type === 'info') {
+            console.warn(`${chalk.bgBlue.white(prefix)} ${chalk.white(line)}`);
+        } else if (message.type === 'warn') {
+            console.warn(`${chalk.bgYellow.black(prefix)} ${chalk.yellow(line)}`);
+        } else if (message.type === 'error') {
+            console.warn(`${chalk.bgRed.white(prefix)} ${chalk.red(line)}`);
+        }
     }
 
     /**

--- a/src/components/Options.js
+++ b/src/components/Options.js
@@ -1,8 +1,65 @@
+const Log = require('../Log');
+
 class Options {
     register(options) {
         Config.merge(options);
 
+        this.messages(options).forEach(Log.message);
+
         return this;
+    }
+
+    /**
+     *
+     * @param {any} options
+     */
+    messages(options) {
+        /** @type {import("../Log").LogMessage[]} */
+        const messages = [];
+
+        if ('extractVueStyles' in options) {
+            messages.push({
+                type: 'warn',
+                text:
+                    'The option extractVueStyles has been moved. Please pass the extractStyles option to mix.vue() instead.'
+            });
+        }
+
+        if ('globalVueStyles' in options) {
+            messages.push({
+                type: 'warn',
+                text:
+                    'The option globalVueStyles has been moved. Please pass the globalStyles option to mix.vue() instead.'
+            });
+        }
+
+        if ('extractVueStyles' in options || 'globalVueStyles' in options) {
+            messages.push({
+                type: 'info',
+                text: `Example:\n${this.buildVueExample(options)}`
+            });
+        }
+
+        return messages;
+    }
+
+    /**
+     *
+     * @param {any} options
+     * @returns {string}
+     */
+    buildVueExample(options) {
+        const props = {};
+
+        if ('extractVueStyles' in options) {
+            props['extractStyles'] = options.extractVueStyles;
+        }
+
+        if ('globalVueStyles' in options) {
+            props['globalStyles'] = options.globalVueStyles;
+        }
+
+        return `mix.vue(${JSON.stringify(props, null, 2)}})`;
     }
 }
 


### PR DESCRIPTION
Closes #2896

This will result in the following if you pass `globalVueStyles` and/or `extractVueStyles` to `mix.options()`:

<img width="780" alt="Vue Warnings" src="https://user-images.githubusercontent.com/614993/111573481-02a79480-8781-11eb-915d-e339dc430d00.png">
