### PR TITLE
Bump cssnano

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
         "commander": "^7.1.0",
         "concat": "^1.0.3",
         "css-loader": "^5.0.0",
-        "cssnano": "^4.1.10",
+        "cssnano": "^4.1.11",
         "dotenv": "^8.2.0",
         "dotenv-expand": "^5.1.0",
         "file-loader": "^6.1.1",


### PR DESCRIPTION
This should fix the CVE-2021-28092 warnings related to is-svg [which is now removed from cssnano as a dependency](https://github.com/cssnano/cssnano/pull/1036). Would be great to get a tag for this one 🙂 

See https://github.com/cssnano/cssnano/pull/1036 

Fixes https://github.com/JeffreyWay/laravel-mix/issues/2908