### PR TITLE
fix TypeScript types

### DIFF
--- a/types/component.d.ts
+++ b/types/component.d.ts
@@ -1,7 +1,8 @@
 // Type definitions for laravel-mix 6.0
 
 import * as webpack from 'webpack';
-import { TransformOptions as BabelConfig } from 'babel-core';
+import { TransformOptions as BabelConfig } from '@babel/core';
+import api from './index';
 
 export type DependencyObject = {
     /** The name of the package */
@@ -73,7 +74,7 @@ export interface ClassComponent {
 }
 
 export interface FunctionalComponent {
-    (mix: Api, config: webpack.Configuration, ...args: any[]): void;
+    (mix: typeof api, config: webpack.Configuration, ...args: any[]): void;
 }
 
 export type Component = ClassComponent | FunctionalComponent;

--- a/types/config.d.ts
+++ b/types/config.d.ts
@@ -8,7 +8,7 @@ import { Options as GifsicleConfig } from 'imagemin-gifsicle';
 import { Options as MozjpegConfig } from 'imagemin-mozjpeg';
 import { Options as OptipngConfig } from 'imagemin-optipng';
 import { Options as SvgoConfig } from 'imagemin-svgo';
-import { TransformOptions as BabelConfig } from 'babel-core';
+import { TransformOptions as BabelConfig } from '@babel/core';
 // import { TerserPluginOptions } from 'terser-webpack-plugin';
 import { TerserPluginOptions } from './terser';
 import { AcceptedPlugin } from 'postcss';


### PR DESCRIPTION
There was some issues in the types:
- `@babel/core` is required as a dependency but is still called `babel-core` in the types
- `API` was not found as a type in the component.d.ts.

Fixes #2954 