### PR TITLE
Pin to previous webpack-dev-server release

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
         "vue-style-loader": "^4.1.3",
         "webpack": "^5.25.1",
         "webpack-cli": "^4.1.0",
-        "webpack-dev-server": "^4.0.0-beta.0",
+        "webpack-dev-server": "4.0.0-beta.2",
         "webpack-merge": "^5.2.0",
         "webpack-notifier": "^1.8.0",
         "webpackbar": "^5.0.0-3",


### PR DESCRIPTION
The original plan was to upgrade but this is the safer option until I've had time to investigate the changes.