### PR TITLE
Don't double load postcss.config.js

### DIFF
--- a/src/PostCssPluginsFactory.js
+++ b/src/PostCssPluginsFactory.js
@@ -1,5 +1,3 @@
-let postcssrc = require('postcss-load-config');
-
 class PostCssPluginsFactory {
     /**
      * Create a new instance.
@@ -30,6 +28,8 @@ class PostCssPluginsFactory {
      * Load the user's postcss.config.js file, if any.
      */
     loadConfigFile() {
+        let postcssrc = require('postcss-load-config');
+
         try {
             this.plugins = [...this.plugins, ...postcssrc.sync().plugins];
         } catch (e) {

--- a/src/PostCssPluginsFactory.js
+++ b/src/PostCssPluginsFactory.js
@@ -15,17 +15,15 @@ class PostCssPluginsFactory {
      * Load all relevant PostCSS plugins.
      */
     load() {
-        this.loadConfigFile()
-            .loadGlobalPlugins()
-            .loadLocalPlugins()
-            .loadAutoprefixer()
-            .loadCssNano();
+        this.loadGlobalPlugins().loadLocalPlugins().loadAutoprefixer().loadCssNano();
 
         return this.plugins;
     }
 
     /**
      * Load the user's postcss.config.js file, if any.
+     *
+     * @deprecated postcss-loader already does this on its own
      */
     loadConfigFile() {
         let postcssrc = require('postcss-load-config');


### PR DESCRIPTION
postcss-loader already does this on its own. If we pass in a list it can cause duplicated plugins inside postcss-loader even after it does plugin de-duplication due to reliance on stable object identity.

Fixes https://github.com/tailwindlabs/tailwindcss/issues/4712