### PR TITLE
Resolve loaders local to laravel-mix first

### DIFF
--- a/src/Mix.js
+++ b/src/Mix.js
@@ -10,6 +10,7 @@ let HotReloading = require('./HotReloading');
 let Manifest = require('./Manifest');
 let Paths = require('./Paths');
 let WebpackConfig = require('./builder/WebpackConfig');
+let { Resolver } = require('./Resolver');
 
 /** @typedef {import("./tasks/Task")} Task */
 
@@ -35,6 +36,7 @@ class Mix {
         this.registrar = new ComponentRegistrar();
         this.webpackConfig = new WebpackConfig(this);
         this.hot = new HotReloading(this);
+        this.resolver = new Resolver();
 
         /** @type {Task[]} */
         this.tasks = [];
@@ -242,6 +244,14 @@ class Mix {
         }
 
         return this.dispatcher.fire(event, data);
+    }
+
+    /**
+     * @param {string} name
+     * @internal
+     */
+    resolve(name) {
+        return this.resolver.get(name);
     }
 
     /**

--- a/src/Resolver.js
+++ b/src/Resolver.js
@@ -1,0 +1,34 @@
+class Resolver {
+    constructor() {
+        /** @type {Record<string, string>} */
+        this.aliases = {};
+    }
+
+    /**
+     *
+     * @param {string} name
+     */
+    get(name) {
+        if (this.aliases[name] !== undefined) {
+            return this.aliases[name];
+        }
+
+        return require.resolve(name);
+    }
+
+    /**
+     *
+     * @param {string} name
+     * @param {string} newName
+     * @internal
+     */
+    alias(name, newName) {
+        this.aliases[name] = require.resolve(newName);
+    }
+
+    clear() {
+        this.aliases = {};
+    }
+}
+
+module.exports.Resolver = Resolver;

--- a/src/VueVersion.js
+++ b/src/VueVersion.js
@@ -2,47 +2,57 @@ let Log = require('./Log');
 
 class VueVersion {
     /**
+     *
+     * @param {import("./Mix")} mix
+     */
+    constructor(mix) {
+        this.mix = mix;
+    }
+
+    /**
      * Vue versions that are supported by Mix.
      *
      * @returns {number[]}
      */
-    static supported() {
+    supported() {
         return [2, 3];
     }
 
     /**
      * Detect and validate the current version of Vue for the build.
      *
-     * @param {number|null} version
+     * @param {string|number|null|undefined} [version]
+     * @returns {number}
      */
-    static detect(version) {
-        version = parseInt(version);
+    detect(version) {
+        version = parseInt(`${version}`);
 
-        if (!version) {
+        if (!version || isNaN(version)) {
             try {
-                return VueVersion.detect(require('vue').version);
+                return this.detect(require(this.mix.resolve('vue')).version);
             } catch (e) {
-                VueVersion.fail();
+                this.fail();
             }
         }
 
-        if (VueVersion.supported().includes(version)) {
+        if (this.supported().includes(version)) {
             return version;
         }
 
-        VueVersion.fail();
+        this.fail();
     }
 
     /**
      * Abort and log that a supported version of Vue wasn't found.
+     * @returns {never}
      */
-    static fail() {
+    fail() {
         Log.error(
             `We couldn't find a supported version of Vue in your project. ` +
                 `Please ensure that it's installed (npm install vue).`
         );
 
-        throw new Error();
+        throw new Error('Unable to detect vue versio');
     }
 }
 

--- a/src/builder/webpack-rules.js
+++ b/src/builder/webpack-rules.js
@@ -12,7 +12,7 @@ module.exports = function (mix) {
     rules.push({
         test: /\.html$/,
         resourceQuery: { not: [/\?vue/i] },
-        use: [{ loader: 'html-loader' }]
+        use: [{ loader: require.resolve('html-loader') }]
     });
 
     if (Config.imgLoaderOptions) {
@@ -22,7 +22,7 @@ module.exports = function (mix) {
             test: /(\.(png|jpe?g|gif|webp)$|^((?!font).)*\.svg$)/,
             use: [
                 {
-                    loader: 'file-loader',
+                    loader: require.resolve('file-loader'),
                     options: {
                         name: path => {
                             if (!/node_modules|bower_components/.test(path)) {
@@ -49,7 +49,7 @@ module.exports = function (mix) {
                 },
 
                 {
-                    loader: 'img-loader',
+                    loader: require.resolve('img-loader'),
                     options: mix.config.imgLoaderOptions
                 }
             ]
@@ -61,7 +61,7 @@ module.exports = function (mix) {
         test: /(\.(woff2?|ttf|eot|otf)$|font.*\.svg$)/,
         use: [
             {
-                loader: 'file-loader',
+                loader: require.resolve('file-loader'),
                 options: {
                     name: path => {
                         if (!/node_modules|bower_components/.test(path)) {
@@ -93,7 +93,7 @@ module.exports = function (mix) {
         test: /\.(cur|ani)$/,
         use: [
             {
-                loader: 'file-loader',
+                loader: require.resolve('file-loader'),
                 options: {
                     name: '[name].[ext]?[hash]',
                     publicPath: mix.config.resourceRoot

--- a/src/components/Coffee.js
+++ b/src/components/Coffee.js
@@ -15,7 +15,7 @@ class Coffee extends JavaScript {
         return [
             {
                 test: /\.coffee$/,
-                use: [{ loader: 'coffee-loader' }]
+                use: [{ loader: require.resolve('coffee-loader') }]
             }
         ].concat(super.webpackRules());
     }

--- a/src/components/CssWebpackConfig.js
+++ b/src/components/CssWebpackConfig.js
@@ -32,7 +32,7 @@ class CssWebpackConfig extends AutomaticComponent {
                 type: 'scss',
                 test: /\.scss$/,
                 loader: {
-                    loader: 'sass-loader',
+                    loader: require.resolve('sass-loader'),
                     options: {
                         sassOptions: {
                             precision: 8,
@@ -46,7 +46,7 @@ class CssWebpackConfig extends AutomaticComponent {
                 type: 'sass',
                 test: /\.sass$/,
                 loader: {
-                    loader: 'sass-loader',
+                    loader: require.resolve('sass-loader'),
                     options: {
                         sassOptions: {
                             precision: 8,
@@ -60,13 +60,13 @@ class CssWebpackConfig extends AutomaticComponent {
                 command: 'less',
                 type: 'less',
                 test: /\.less$/,
-                loader: { loader: 'less-loader' }
+                loader: { loader: require.resolve('less-loader') }
             },
             {
                 command: 'stylus',
                 type: 'stylus',
                 test: /\.styl(us)?$/,
-                loader: { loader: 'stylus-loader' }
+                loader: { loader: require.resolve('stylus-loader') }
             }
         ].map(rule => this.createRule(rule));
     }
@@ -107,7 +107,7 @@ class CssWebpackConfig extends AutomaticComponent {
         return [
             ...CssWebpackConfig.afterLoaders(),
             {
-                loader: 'css-loader',
+                loader: require.resolve('css-loader'),
                 options: {
                     url: (url, resourcePath) => {
                         if (url.startsWith('/')) {
@@ -120,7 +120,7 @@ class CssWebpackConfig extends AutomaticComponent {
                 }
             },
             {
-                loader: 'postcss-loader',
+                loader: require.resolve('postcss-loader'),
                 options: {
                     postcssOptions: {
                         plugins: new PostCssPluginsFactory({}, Config).load(),
@@ -187,9 +187,9 @@ class CssWebpackConfig extends AutomaticComponent {
 
         if (method === 'inline') {
             if (this.wantsVueStyleLoader && location === 'default') {
-                loaders.push({ loader: 'vue-style-loader' });
+                loaders.push({ loader: require.resolve('vue-style-loader') });
             } else {
-                loaders.push({ loader: 'style-loader' });
+                loaders.push({ loader: require.resolve('style-loader') });
             }
         } else if (method === 'extract') {
             loaders.push({
@@ -232,7 +232,7 @@ class CssWebpackConfig extends AutomaticComponent {
 
             if (resources.length) {
                 loaders.push({
-                    loader: 'sass-resources-loader',
+                    loader: require.resolve('sass-resources-loader'),
                     options: {
                         hoistUseStatements: true,
                         resources

--- a/src/components/JavaScript.js
+++ b/src/components/JavaScript.js
@@ -62,7 +62,7 @@ class JavaScript {
                 exclude: /(node_modules|bower_components)/,
                 use: [
                     {
-                        loader: 'babel-loader',
+                        loader: require.resolve('babel-loader'),
                         options: Config.babel()
                     }
                 ]

--- a/src/components/Preprocessor.js
+++ b/src/components/Preprocessor.js
@@ -55,7 +55,7 @@ class Preprocessor {
         let loaders = [
             ...CssWebpackConfig.afterLoaders({ method: 'extract', location: 'per-file' }),
             {
-                loader: 'css-loader',
+                loader: require.resolve('css-loader'),
                 options: {
                     url: (url, resourcePath) => {
                         if (url.startsWith('/')) {
@@ -69,14 +69,14 @@ class Preprocessor {
                 }
             },
             {
-                loader: 'postcss-loader',
+                loader: require.resolve('postcss-loader'),
                 options: this.postCssLoaderOptions(preprocessor)
             }
         ];
 
         if (preprocessor.type === 'sass' && processUrls) {
             loaders.push({
-                loader: 'resolve-url-loader',
+                loader: require.resolve('resolve-url-loader'),
                 options: {
                     sourceMap: true
                 }

--- a/src/components/TypeScript.js
+++ b/src/components/TypeScript.js
@@ -38,7 +38,7 @@ class TypeScript extends JavaScript {
     webpackRules() {
         return [].concat(super.webpackRules(), {
             test: /\.tsx?$/,
-            loader: 'ts-loader',
+            loader: require.resolve('ts-loader'),
             exclude: /node_modules/,
             options: Object.assign(
                 {},

--- a/src/components/Vue.js
+++ b/src/components/Vue.js
@@ -34,7 +34,7 @@ class Vue {
             );
         }
 
-        this.version = VueVersion.detect(options.version);
+        this.version = new VueVersion(this._mix).detect(options.version);
 
         this.options = Object.assign(
             {
@@ -79,7 +79,7 @@ class Vue {
             test: /\.vue$/,
             use: [
                 {
-                    loader: 'vue-loader',
+                    loader: this._mix.resolve('vue-loader'),
                     options: this.options.options || Config.vue || {}
                 }
             ]
@@ -113,7 +113,7 @@ class Vue {
      * webpack plugins to be appended to the master config.
      */
     webpackPlugins() {
-        let { VueLoaderPlugin } = require('vue-loader');
+        let { VueLoaderPlugin } = require(this._mix.resolve('vue-loader'));
 
         return [new VueLoaderPlugin(), new AppendVueStylesPlugin()];
     }
@@ -189,6 +189,15 @@ class Vue {
                 : '/css/vue-styles.css';
 
         return fileName.replace(Config.publicPath, '').replace(/^\//, '');
+    }
+
+    /**
+     * @internal
+     * @returns {import("../Mix")}
+     **/
+    get _mix() {
+        // @ts-ignore
+        return global.Mix;
     }
 }
 

--- a/test/features/preprocessors.js
+++ b/test/features/preprocessors.js
@@ -134,7 +134,7 @@ test('Unique PostCSS plugins can be applied for each mix.sass/less/stylus() call
         t.true(
             config.module.rules
                 .find(rule => rule.test.toString().includes(file))
-                .use.find(loader => loader.loader === 'postcss-loader')
+                .use.find(loader => /postcss-loader/.test(loader.loader))
                 .options.postcssOptions.plugins.find(
                     plugin => plugin.postcssPlugin === pluginName
                 ) !== undefined

--- a/test/helpers/assertions.js
+++ b/test/helpers/assertions.js
@@ -25,7 +25,7 @@ function hasWebpackRule(config, test) {
 function hasWebpackLoader(config, loader) {
     const checkLoader =
         typeof loader === 'string'
-            ? str => str === loader
+            ? str => new RegExp(`[\/\\\\]${loader}[\/\\\\]`).test(str)
             : loader instanceof RegExp
             ? str => loader.test(str)
             : loader;

--- a/test/helpers/webpack.js
+++ b/test/helpers/webpack.js
@@ -1,4 +1,3 @@
-import mockRequire from 'mock-require';
 import webpack from 'webpack';
 
 import { mix, Mix } from './mix.js';
@@ -51,18 +50,10 @@ export function setupVueAliases(version) {
     const vueModule = version === 3 ? 'vue3' : 'vue2';
     const vueLoaderModule = version === 3 ? 'vue-loader16' : 'vue-loader15';
 
-    mockRequire('vue', vueModule);
-    mockRequire('vue-loader', vueLoaderModule);
+    Mix.resolver.alias('vue', vueModule);
+    Mix.resolver.alias('vue-loader', vueLoaderModule);
 
     mix.alias({ vue: require.resolve(vueModule) });
-
-    mix.webpackConfig({
-        resolveLoader: {
-            alias: {
-                'vue-loader': vueLoaderModule
-            }
-        }
-    });
 }
 
 export default { buildConfig, compile, setupVueAliases };

--- a/test/unit/VueVersion.js
+++ b/test/unit/VueVersion.js
@@ -1,41 +1,52 @@
-import test from 'ava';
+import test, { afterEach, beforeEach } from 'ava';
 import mockRequire from 'mock-require';
 
 import Log from '../../src/Log.js';
+import Mix from '../../src/Mix.js';
 import VueVersion from '../../src/VueVersion.js';
 
+let mix = new Mix();
+let vueVersion = new VueVersion(mix);
+
+beforeEach(() => mix.resolver.clear());
+afterEach(() => mix.resolver.clear());
+
 test('it detects Vue 2', t => {
-    mockRequire('vue', { version: '2.0' });
+    mockRequire('vue2', { version: '2.0' });
+    mix.resolver.alias('vue', 'vue2');
 
-    t.is(2, VueVersion.detect());
+    t.is(2, vueVersion.detect());
 
-    mockRequire.stop('vue');
+    mockRequire.stop('vue2');
 });
 
 test('it detects Vue 3', t => {
-    mockRequire('vue', { version: '3.0' });
+    mockRequire('vue3', { version: '3.0' });
+    mix.resolver.alias('vue', 'vue3');
 
-    t.is(3, VueVersion.detect());
+    t.is(3, vueVersion.detect());
 
-    mockRequire.stop('vue');
+    mockRequire.stop('vue3');
 });
 
-test('it aborts if Vue is not installed', t => {
+test.only('it aborts if Vue is not installed', async t => {
     Log.fake();
 
-    t.throws(() => VueVersion.detect());
+    t.throws(() => vueVersion.detect());
 
     t.true(Log.received(`couldn't find a supported version of Vue`));
 });
 
 test('it aborts if an unsupported Vue version is provided', t => {
-    mockRequire('vue', { version: '100.0' });
+    // TODO: This has to use the name of an actual module because of the switch to require.resolve
+    mockRequire('vue3', { version: '100.0' });
+    mix.resolver.alias('vue', 'vue3');
 
     Log.fake();
 
-    t.throws(() => VueVersion.detect(100));
+    t.throws(() => vueVersion.detect(100));
 
     t.true(Log.received(`couldn't find a supported version of Vue`));
 
-    mockRequire.stop('vue');
+    mockRequire.stop('vue3');
 });


### PR DESCRIPTION
NPM 7's peer dependency installation can put incompatible modules at the top level. We want to load dependencies relative to Mix instead but webpack doesn't know that. So we use `require.resolve` to turn loader names into full paths. If Mix does not depend on modules directly then this will still load from the top level of the project.

Gonna let this run the tests, do some more testing locally tonight and then merge.

Fix #3036
Fix #3043

Thanks @ankurk91 for the tip here
