### PR TITLE
Attempt better fix for Node 17

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -81,7 +81,7 @@ async function executeScript(cmd, opts, args = []) {
         MIX_FILE: opts.mixConfig
     };
 
-    const nodeEnv = process.version.startsWith('v17.')
+    const nodeEnv = requiresLegacyOpenSSLProvider()
         ? { NODE_OPTIONS: process.env.NODE_OPTIONS || `--openssl-legacy-provider` }
         : {};
 
@@ -222,4 +222,18 @@ function isTTY() {
     }
 
     return process.stdout.isTTY;
+}
+
+function requiresLegacyOpenSSLProvider() {
+    if (!process.version.startsWith('v17.')) {
+        return false;
+    }
+
+    try {
+        require('crypto').createHash('md4').update('test').digest('hex');
+
+        return false;
+    } catch (err) {
+        return true;
+    }
 }


### PR DESCRIPTION
Apparently --openssl-legacy-provider doesn't always exist. This is gonna be fun…

I can't reproduce this on GitHub actions or locally so I don't know what the criteria are for when it's available as a flag and when it's not.

Hopefully fixes #3137 (again…)