### PR TITLE
Update to webpack-cli v5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53,7 +53,7 @@
                 "terser-webpack-plugin": "^5.2.4",
                 "vue-style-loader": "^4.1.3",
                 "webpack": "^5.60.0",
-                "webpack-cli": "^4.9.1",
+                "webpack-cli": "^5.0.0",
                 "webpack-dev-server": "^4.7.3",
                 "webpack-merge": "^5.8.0",
                 "webpack-notifier": "^1.14.1",
@@ -136,7 +136,7 @@
                 "@babel/preset-env": "^7.15.8",
                 "postcss": "^8.3.11",
                 "webpack": "^5.60.0",
-                "webpack-cli": "^4.9.1"
+                "webpack-cli": "^4.9.1 || ^5.0.0"
             }
         },
         "node_modules/@babel/code-frame": {
@@ -3033,31 +3033,39 @@
             }
         },
         "node_modules/@webpack-cli/configtest": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-1.1.0.tgz",
-            "integrity": "sha512-ttOkEkoalEHa7RaFYpM0ErK1xc4twg3Am9hfHhL7MVqlHebnkYd2wuI/ZqTDj0cVzZho6PdinY0phFZV3O0Mzg==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-2.0.0.tgz",
+            "integrity": "sha512-war4OU8NGjBqU3DP3bx6ciODXIh7dSXcpQq+P4K2Tqyd8L5OjZ7COx9QXx/QdCIwL2qoX09Wr4Cwf7uS4qdEng==",
+            "engines": {
+                "node": ">=14.15.0"
+            },
             "peerDependencies": {
-                "webpack": "4.x.x || 5.x.x",
-                "webpack-cli": "4.x.x"
+                "webpack": "5.x.x",
+                "webpack-cli": "5.x.x"
             }
         },
         "node_modules/@webpack-cli/info": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-1.4.0.tgz",
-            "integrity": "sha512-F6b+Man0rwE4n0409FyAJHStYA5OIZERxmnUfLVwv0mc0V1wLad3V7jqRlMkgKBeAq07jUvglacNaa6g9lOpuw==",
-            "dependencies": {
-                "envinfo": "^7.7.3"
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-2.0.0.tgz",
+            "integrity": "sha512-NNxDgbo4VOkNhOlTgY0Elhz3vKpOJq4/PKeKg7r8cmYM+GQA9vDofLYyup8jS6EpUvhNmR30cHTCEIyvXpskwA==",
+            "engines": {
+                "node": ">=14.15.0"
             },
             "peerDependencies": {
-                "webpack-cli": "4.x.x"
+                "webpack": "5.x.x",
+                "webpack-cli": "5.x.x"
             }
         },
         "node_modules/@webpack-cli/serve": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.6.0.tgz",
-            "integrity": "sha512-ZkVeqEmRpBV2GHvjjUZqEai2PpUbuq8Bqd//vEYsp63J8WyexI8ppCqVS3Zs0QADf6aWuPdU+0XsPI647PVlQA==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-2.0.0.tgz",
+            "integrity": "sha512-Rumq5mHvGXamnOh3O8yLk1sjx8dB30qF1OeR6VC00DIR6SLJ4bwwUGKC4pE7qBFoQyyh0H9sAg3fikYgAqVR0w==",
+            "engines": {
+                "node": ">=14.15.0"
+            },
             "peerDependencies": {
-                "webpack-cli": "4.x.x"
+                "webpack": "5.x.x",
+                "webpack-cli": "5.x.x"
             },
             "peerDependenciesMeta": {
                 "webpack-dev-server": {
@@ -7300,11 +7308,11 @@
             "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
         },
         "node_modules/interpret": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/interpret/-/interpret-2.2.0.tgz",
-            "integrity": "sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw==",
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/interpret/-/interpret-3.1.1.tgz",
+            "integrity": "sha512-6xwYfHbajpoF0xLW+iwLkhwgvLoZDfjYfoFNu8ftMoXINzwuymNLd9u/KmwtdT2GbR+/Cz66otEGEVVUHX9QLQ==",
             "engines": {
-                "node": ">= 0.10"
+                "node": ">=10.13.0"
             }
         },
         "node_modules/ip": {
@@ -10694,14 +10702,14 @@
             }
         },
         "node_modules/rechoir": {
-            "version": "0.7.1",
-            "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.7.1.tgz",
-            "integrity": "sha512-/njmZ8s1wVeR6pjTZ+0nCnv8SpZNRMT2D1RLOJQESlYFDBvwpTA4KWJpZ+sBJ4+vhjILRcK7JIFdGCdxEAAitg==",
+            "version": "0.8.0",
+            "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.8.0.tgz",
+            "integrity": "sha512-/vxpCXddiX8NGfGO/mTafwjq4aFa/71pvamip0++IQk3zG8cbCj0fifNPrjjF1XMXUne91jL9OoxmdykoEtifQ==",
             "dependencies": {
-                "resolve": "^1.9.0"
+                "resolve": "^1.20.0"
             },
             "engines": {
-                "node": ">= 0.10"
+                "node": ">= 10.13.0"
             }
         },
         "node_modules/regenerate": {
@@ -11247,6 +11255,18 @@
             "dependencies": {
                 "type-fest": "^0.13.1"
             },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/serialize-error/node_modules/type-fest": {
+            "version": "0.13.1",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
+            "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
+            "dev": true,
             "engines": {
                 "node": ">=10"
             },
@@ -12504,12 +12524,14 @@
             }
         },
         "node_modules/type-fest": {
-            "version": "0.13.1",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
-            "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
+            "version": "2.19.0",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+            "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
             "dev": true,
+            "optional": true,
+            "peer": true,
             "engines": {
-                "node": ">=10"
+                "node": ">=12.20"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
@@ -12911,37 +12933,39 @@
             }
         },
         "node_modules/webpack-cli": {
-            "version": "4.9.1",
-            "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-4.9.1.tgz",
-            "integrity": "sha512-JYRFVuyFpzDxMDB+v/nanUdQYcZtqFPGzmlW4s+UkPMFhSpfRNmf1z4AwYcHJVdvEFAM7FFCQdNTpsBYhDLusQ==",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-5.0.0.tgz",
+            "integrity": "sha512-AACDTo20yG+xn6HPW5xjbn2Be4KUzQPebWXsDMHwPPyKh9OnTOJgZN2Nc+g/FZKV3ObRTYsGvibAvc+5jAUrVA==",
             "dependencies": {
                 "@discoveryjs/json-ext": "^0.5.0",
-                "@webpack-cli/configtest": "^1.1.0",
-                "@webpack-cli/info": "^1.4.0",
-                "@webpack-cli/serve": "^1.6.0",
+                "@webpack-cli/configtest": "^2.0.0",
+                "@webpack-cli/info": "^2.0.0",
+                "@webpack-cli/serve": "^2.0.0",
                 "colorette": "^2.0.14",
-                "commander": "^7.0.0",
-                "execa": "^5.0.0",
+                "commander": "^9.4.1",
+                "cross-spawn": "^7.0.3",
+                "envinfo": "^7.7.3",
                 "fastest-levenshtein": "^1.0.12",
                 "import-local": "^3.0.2",
-                "interpret": "^2.2.0",
-                "rechoir": "^0.7.0",
+                "interpret": "^3.1.1",
+                "rechoir": "^0.8.0",
                 "webpack-merge": "^5.7.3"
             },
             "bin": {
                 "webpack-cli": "bin/cli.js"
             },
             "engines": {
-                "node": ">=10.13.0"
+                "node": ">=14.15.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/webpack"
             },
             "peerDependencies": {
-                "webpack": "4.x.x || 5.x.x"
+                "webpack": "5.x.x"
             },
             "peerDependenciesMeta": {
                 "@webpack-cli/generators": {
-                    "optional": true
-                },
-                "@webpack-cli/migrate": {
                     "optional": true
                 },
                 "webpack-bundle-analyzer": {
@@ -12952,45 +12976,12 @@
                 }
             }
         },
-        "node_modules/webpack-cli/node_modules/execa": {
-            "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
-            "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
-            "dependencies": {
-                "cross-spawn": "^7.0.3",
-                "get-stream": "^6.0.0",
-                "human-signals": "^2.1.0",
-                "is-stream": "^2.0.0",
-                "merge-stream": "^2.0.0",
-                "npm-run-path": "^4.0.1",
-                "onetime": "^5.1.2",
-                "signal-exit": "^3.0.3",
-                "strip-final-newline": "^2.0.0"
-            },
+        "node_modules/webpack-cli/node_modules/commander": {
+            "version": "9.4.1",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-9.4.1.tgz",
+            "integrity": "sha512-5EEkTNyHNGFPD2H+c/dXXfQZYa/scCKasxWcXJaWnNJ99pnQN9Vnmqow+p+PlFPE63Q6mThaZws1T+HxfpgtPw==",
             "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sindresorhus/execa?sponsor=1"
-            }
-        },
-        "node_modules/webpack-cli/node_modules/get-stream": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
-            "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/webpack-cli/node_modules/human-signals": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
-            "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
-            "engines": {
-                "node": ">=10.17.0"
+                "node": "^12.20.0 || >=14"
             }
         },
         "node_modules/webpack-dev-middleware": {
@@ -15735,23 +15726,21 @@
             }
         },
         "@webpack-cli/configtest": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-1.1.0.tgz",
-            "integrity": "sha512-ttOkEkoalEHa7RaFYpM0ErK1xc4twg3Am9hfHhL7MVqlHebnkYd2wuI/ZqTDj0cVzZho6PdinY0phFZV3O0Mzg==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-2.0.0.tgz",
+            "integrity": "sha512-war4OU8NGjBqU3DP3bx6ciODXIh7dSXcpQq+P4K2Tqyd8L5OjZ7COx9QXx/QdCIwL2qoX09Wr4Cwf7uS4qdEng==",
             "requires": {}
         },
         "@webpack-cli/info": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-1.4.0.tgz",
-            "integrity": "sha512-F6b+Man0rwE4n0409FyAJHStYA5OIZERxmnUfLVwv0mc0V1wLad3V7jqRlMkgKBeAq07jUvglacNaa6g9lOpuw==",
-            "requires": {
-                "envinfo": "^7.7.3"
-            }
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-2.0.0.tgz",
+            "integrity": "sha512-NNxDgbo4VOkNhOlTgY0Elhz3vKpOJq4/PKeKg7r8cmYM+GQA9vDofLYyup8jS6EpUvhNmR30cHTCEIyvXpskwA==",
+            "requires": {}
         },
         "@webpack-cli/serve": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.6.0.tgz",
-            "integrity": "sha512-ZkVeqEmRpBV2GHvjjUZqEai2PpUbuq8Bqd//vEYsp63J8WyexI8ppCqVS3Zs0QADf6aWuPdU+0XsPI647PVlQA==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-2.0.0.tgz",
+            "integrity": "sha512-Rumq5mHvGXamnOh3O8yLk1sjx8dB30qF1OeR6VC00DIR6SLJ4bwwUGKC4pE7qBFoQyyh0H9sAg3fikYgAqVR0w==",
             "requires": {}
         },
         "@xtuc/ieee754": {
@@ -18938,9 +18927,9 @@
             "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
         },
         "interpret": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/interpret/-/interpret-2.2.0.tgz",
-            "integrity": "sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw=="
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/interpret/-/interpret-3.1.1.tgz",
+            "integrity": "sha512-6xwYfHbajpoF0xLW+iwLkhwgvLoZDfjYfoFNu8ftMoXINzwuymNLd9u/KmwtdT2GbR+/Cz66otEGEVVUHX9QLQ=="
         },
         "ip": {
             "version": "1.1.5",
@@ -21404,11 +21393,11 @@
             }
         },
         "rechoir": {
-            "version": "0.7.1",
-            "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.7.1.tgz",
-            "integrity": "sha512-/njmZ8s1wVeR6pjTZ+0nCnv8SpZNRMT2D1RLOJQESlYFDBvwpTA4KWJpZ+sBJ4+vhjILRcK7JIFdGCdxEAAitg==",
+            "version": "0.8.0",
+            "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.8.0.tgz",
+            "integrity": "sha512-/vxpCXddiX8NGfGO/mTafwjq4aFa/71pvamip0++IQk3zG8cbCj0fifNPrjjF1XMXUne91jL9OoxmdykoEtifQ==",
             "requires": {
-                "resolve": "^1.9.0"
+                "resolve": "^1.20.0"
             }
         },
         "regenerate": {
@@ -21817,6 +21806,14 @@
             "dev": true,
             "requires": {
                 "type-fest": "^0.13.1"
+            },
+            "dependencies": {
+                "type-fest": {
+                    "version": "0.13.1",
+                    "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
+                    "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
+                    "dev": true
+                }
             }
         },
         "serialize-javascript": {
@@ -22771,10 +22768,12 @@
             "dev": true
         },
         "type-fest": {
-            "version": "0.13.1",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
-            "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
-            "dev": true
+            "version": "2.19.0",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+            "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+            "dev": true,
+            "optional": true,
+            "peer": true
         },
         "type-is": {
             "version": "1.6.18",
@@ -23101,49 +23100,29 @@
             }
         },
         "webpack-cli": {
-            "version": "4.9.1",
-            "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-4.9.1.tgz",
-            "integrity": "sha512-JYRFVuyFpzDxMDB+v/nanUdQYcZtqFPGzmlW4s+UkPMFhSpfRNmf1z4AwYcHJVdvEFAM7FFCQdNTpsBYhDLusQ==",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-5.0.0.tgz",
+            "integrity": "sha512-AACDTo20yG+xn6HPW5xjbn2Be4KUzQPebWXsDMHwPPyKh9OnTOJgZN2Nc+g/FZKV3ObRTYsGvibAvc+5jAUrVA==",
             "requires": {
                 "@discoveryjs/json-ext": "^0.5.0",
-                "@webpack-cli/configtest": "^1.1.0",
-                "@webpack-cli/info": "^1.4.0",
-                "@webpack-cli/serve": "^1.6.0",
+                "@webpack-cli/configtest": "^2.0.0",
+                "@webpack-cli/info": "^2.0.0",
+                "@webpack-cli/serve": "^2.0.0",
                 "colorette": "^2.0.14",
-                "commander": "^7.0.0",
-                "execa": "^5.0.0",
+                "commander": "^9.4.1",
+                "cross-spawn": "^7.0.3",
+                "envinfo": "^7.7.3",
                 "fastest-levenshtein": "^1.0.12",
                 "import-local": "^3.0.2",
-                "interpret": "^2.2.0",
-                "rechoir": "^0.7.0",
+                "interpret": "^3.1.1",
+                "rechoir": "^0.8.0",
                 "webpack-merge": "^5.7.3"
             },
             "dependencies": {
-                "execa": {
-                    "version": "5.1.1",
-                    "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
-                    "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
-                    "requires": {
-                        "cross-spawn": "^7.0.3",
-                        "get-stream": "^6.0.0",
-                        "human-signals": "^2.1.0",
-                        "is-stream": "^2.0.0",
-                        "merge-stream": "^2.0.0",
-                        "npm-run-path": "^4.0.1",
-                        "onetime": "^5.1.2",
-                        "signal-exit": "^3.0.3",
-                        "strip-final-newline": "^2.0.0"
-                    }
-                },
-                "get-stream": {
-                    "version": "6.0.1",
-                    "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
-                    "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg=="
-                },
-                "human-signals": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
-                    "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw=="
+                "commander": {
+                    "version": "9.4.1",
+                    "resolved": "https://registry.npmjs.org/commander/-/commander-9.4.1.tgz",
+                    "integrity": "sha512-5EEkTNyHNGFPD2H+c/dXXfQZYa/scCKasxWcXJaWnNJ99pnQN9Vnmqow+p+PlFPE63Q6mThaZws1T+HxfpgtPw=="
                 }
             }
         },

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
         "terser-webpack-plugin": "^5.2.4",
         "vue-style-loader": "^4.1.3",
         "webpack": "^5.60.0",
-        "webpack-cli": "^4.9.1",
+        "webpack-cli": "^5.0.0",
         "webpack-dev-server": "^4.7.3",
         "webpack-merge": "^5.8.0",
         "webpack-notifier": "^1.14.1",
@@ -159,7 +159,7 @@
         "@babel/preset-env": "^7.15.8",
         "postcss": "^8.3.11",
         "webpack": "^5.60.0",
-        "webpack-cli": "^4.9.1"
+        "webpack-cli": "^4.9.1 || ^5.0.0"
     },
     "engines": {
         "node": ">=12.14.0"


### PR DESCRIPTION
Webpack CLI v5 has been released, see https://github.com/webpack/webpack-cli/releases/tag/webpack-cli%405.0.0.

The main breaking change is dropping support for Webpack v4, but as this package is already based on Webpack v5, this should not cause any problems.