### PR TITLE
Fix CustomTasksPlugin regenerating all files on watch file change.

### DIFF
--- a/src/webpackPlugins/CustomTasksPlugin.js
+++ b/src/webpackPlugins/CustomTasksPlugin.js
@@ -16,8 +16,13 @@ class CustomTasksPlugin {
      * @param {import("webpack").Compiler} compiler
      */
     apply(compiler) {
+        let firstTime = true;
+
         compiler.hooks.done.tapPromise(this.constructor.name, async stats => {
-            await this.runTasks(stats);
+            if (firstTime) {
+                await this.runTasks(stats);
+                firstTime = false;
+            }
 
             if (this.mix.components.get('version') && !this.mix.isUsing('hmr')) {
                 this.applyVersioning();


### PR DESCRIPTION
Fixes 'combine', 'scripts', 'babel', 'styles', 'minify' functions causing all files to be regenerated on watch file change.

This breaks functionality of live reloading programs that watch for individual file changes. 

Example would be: 
`mix.styles(['./test1.scss', './test2.scss'], './test.min.css');`
This shouldn't cause a page load on either test1 or test2 being changed, but it will without this update.

See here for previous discussion: https://github.com/laravel-mix/laravel-mix/issues/1053