### PR TITLE
Silence ESM bundler warning for Vue 3

### DIFF
--- a/src/components/Vue.js
+++ b/src/components/Vue.js
@@ -244,7 +244,8 @@ module.exports = class Vue extends Component {
 
         this.context.api.define({
             __VUE_OPTIONS_API__: 'true',
-            __VUE_PROD_DEVTOOLS__: 'false'
+            __VUE_PROD_DEVTOOLS__: 'false',
+            __VUE_PROD_HYDRATION_MISMATCH_DETAILS__: 'false'
         });
     }
 };

--- a/test/features/vue.js
+++ b/test/features/vue.js
@@ -410,7 +410,8 @@ export function setupVueTests({ version, dir }) {
             .file(`test/fixtures/app/dist/js/app.js`)
             .doesNotContain([
                 'typeof __VUE_OPTIONS_API__',
-                'typeof __VUE_PROD_DEVTOOLS__'
+                'typeof __VUE_PROD_DEVTOOLS__',
+                'typeof __VUE_PROD_HYDRATION_MISMATCH_DETAILS__'
             ]);
     });
 


### PR DESCRIPTION
As stated in the Vue documentation: https://vuejs.org/api/compile-time-flags#webpack 

`__VUE_PROD_HYDRATION_MISMATCH_DETAILS__` should be set to `false` by default, otherwise, this warning pops up:

> Feature flag __VUE_PROD_HYDRATION_MISMATCH_DETAILS__ is not explicitly defined. You are running the esm-bundler build of Vue, which expects these compile-time feature flags to be globally injected via the bundler config in order to get better tree-shaking in the production bundle.